### PR TITLE
Inc dec

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,42 @@
   "object": {
     "pins": [
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "fb7a26374e8570ff5c68142e5c83406d6abae0d8",
+          "version": "2.0.2"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
+          "version": "4.0.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -24,6 +24,6 @@ let package = Package(
             dependencies: ["SwiftCli"]),
         .testTarget(
             name: "SwiftCliCoreTests",
-            dependencies: ["SwiftCliCore"]),
+            dependencies: ["SwiftCliCore"])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "4.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "9.1.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "9.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "4.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "9.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -24,6 +26,6 @@ let package = Package(
             dependencies: ["SwiftCli"]),
         .testTarget(
             name: "SwiftCliCoreTests",
-            dependencies: ["SwiftCliCore"])
+            dependencies: ["SwiftCliCore", "Nimble", "Quick"])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Minimum Swift version required to run this project: 5.3
 
 To install this project on your machine use 
 `git clone https://github.com/graceolivia/Chartify2000.git`
+`swift build`
 
 To run the project, either use the Run command on XCODE, or cd into the directory on the terminal and do:
 
-`swift build`
+
 `swift run`
 
 To test the project, either use XCODE tools to run tests as you wish, or in the project directory on the terminal run:

--- a/README.md
+++ b/README.md
@@ -25,3 +25,18 @@ Current supported stitches/input, and how they are rendered:
 | m1   | m        |
 
 
+## Developer information
+
+Minimum Swift version required to run this project: 5.3
+
+To install this project on your machine use 
+`git clone https://github.com/graceolivia/Chartify2000.git`
+
+To run the project, either use the Run command on XCODE, or cd into the directory on the terminal and do:
+
+`swift build`
+`swift run`
+
+To test the project, either use XCODE tools to run tests as you wish, or in the project directory on the terminal run:
+
+`swift test`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # Chartify
 
 Turn your written knitting pattern into a handsome chart!
+
+Chartify takes input in the form of allowed stitches, seperated by line breaks (eventually user input), and returns an ASCII chart.
+
+For example, input the string "k1 k1 p1 p1 k1 k1 \n p1 p1 k1 k1 p1 p1," and Chartify will crate this pattern:
+
+┌─┬─┬─┬─┬─┬─┐
+│-│-│ │ │-│-│
+├─┼─┼─┼─┼─┼─┤
+│ │ │-│-│ │ │
+└─┴─┴─┴─┴─┴─┘
+
+
+Current supported stitches/input, and how they are rendered:
+
+| Stitch     | Rendering |
+| ----------- | ----------- |
+| k1      | blank box       |
+| p1   | -        |
+| ssk   | \        |
+| k2tog   | /        |
+| yo   | o        |
+| m1   | m        |
+
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Chartify takes input in the form of allowed stitches, seperated by line breaks (
 
 For example, input the string "k1 k1 p1 p1 k1 k1 \n p1 p1 k1 k1 p1 p1," and Chartify will crate this pattern:
 
-┌─┬─┬─┬─┬─┬─┐
+┌─┬─┬─┬─┬─┬─┐  
 │-│-│ │ │-│-│
 ├─┼─┼─┼─┼─┼─┤
 │ │ │-│-│ │ │

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -66,7 +66,6 @@ public class ChartConstructor {
         var middleStitches = ""
         var rightStitches = ""
 
-
         switch lDiff {
         case 0:
             leftStitches = "├"
@@ -81,8 +80,7 @@ public class ChartConstructor {
             middleStitches = String(repeating: "─┼", count: (width-1))
         }
 
-
-        switch (true){
+        switch true {
         case (rDiff >= 1):
             rightStitches = ""
         case (rDiff == -1):
@@ -93,8 +91,6 @@ public class ChartConstructor {
         default:
             rightStitches = "─┤\n"
         }
-
-
 
         return leftStitches + middleStitches + rightStitches
 
@@ -115,7 +111,7 @@ public class ChartConstructor {
 
     public func makeStitchRow(row: [String]) -> String {
         var width = row.count
-        switch width{
+        switch width {
         case 0:
             return "\n"
         default:

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -62,16 +62,9 @@ public class ChartConstructor {
     }
 
     public func makeMiddleRowStitchCountChange(width: Int, rDiff: Int, lDiff: Int) -> String {
-        var leftStitches = ""
-        var middleStitches = ""
+        let leftStitches = "├"
         var rightStitches = ""
-
-        switch lDiff {
-        case 0:
-            leftStitches = "├"
-        default:
-            leftStitches = "├"
-        }
+        var middleStitches = ""
 
         switch width {
         case 1:
@@ -81,13 +74,13 @@ public class ChartConstructor {
         }
 
         switch true {
-        case (rDiff >= 1):
-            rightStitches = ""
-        case (rDiff == -1):
-            rightStitches = "─┼─┐\n"
         case (rDiff < -1):
             let midRightSt = String(repeating: "─┬", count: ((abs(rDiff))-1))
             rightStitches = "─┼\(midRightSt)─┐\n"
+        case (rDiff == -1):
+            rightStitches = "─┼─┐\n"
+        case (rDiff == 0):
+            rightStitches = "─┤\n"
         default:
             rightStitches = "─┤\n"
         }
@@ -106,19 +99,18 @@ public class ChartConstructor {
         default:
             let middleBoxes = String(repeating: "─┴", count: width - 1)
             return "└\(middleBoxes)─┘"
-    }
+        }
     }
 
     public func makeStitchRow(row: [String]) -> String {
-        var width = row.count
+        let width = row.count
         switch width {
         case 0:
             return "\n"
         default:
             var middleStitches = ""
             for stitch in row {
-                middleStitches += stitchPrinting[stitch] ?? ""
-                middleStitches += "│"
+                middleStitches += "\(stitchPrinting[stitch] ?? "")|"
             }
             return "│\(middleStitches)\n"
         }

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -90,7 +90,6 @@ public class ChartConstructor {
     }
 
     public func makeBottomRow(width: Int) -> String {
-
         switch width {
         case 0:
             return ""

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -8,13 +8,13 @@ public class ChartConstructor {
         let number_of_rows = stitch_array.count
         var finished_chart = ""
         let lastrow = number_of_rows - 1
-        // NEW LOGIC
+        
         for row in 0...lastrow {
             let row_length = stitch_array[row].count
             
             if (row == 0){
-                finished_chart =  self.make_bottom_row(width: row_length) + finished_chart
-                finished_chart = self.make_stitch_row(row: stitch_array[row]) + finished_chart
+                finished_chart =  makeBottomRow(width: row_length) + finished_chart
+                finished_chart = makeStitchRow(row: stitch_array[row]) + finished_chart
             }
             
             
@@ -22,98 +22,88 @@ public class ChartConstructor {
                 let prev_row_length = stitch_array[row - 1].count
                 let right_side_diff = (row_length - prev_row_length)
                 if (right_side_diff < 0){
-                    print("here")
-                    finished_chart =  make_middle_row_stitch_count_change(width: row_length, right_difference: right_side_diff, left_difference: 0) + finished_chart
+                    
+                    finished_chart =  makeMiddleRowStitchCountChange(width: row_length, right_difference: right_side_diff, left_difference: 0) + finished_chart
                 }
                 else {
-                    finished_chart = self.make_middle_row(width: row_length) + finished_chart
+                    finished_chart = makeMiddleRow(width: row_length) + finished_chart
                 }
                 
-                finished_chart = self.make_stitch_row(row: stitch_array[row]) + finished_chart
-
-                }
-            
-            //if last row
-            if (row == (number_of_rows - 1)){
-                finished_chart = self.make_top_row(width: row_length) + finished_chart
-
+                finished_chart = makeStitchRow(row: stitch_array[row]) + finished_chart
+                
             }
-
+            
+            
+            if (row == (number_of_rows - 1)){
+                finished_chart = makeTopRow(width: row_length) + finished_chart
+                
+            }
+            
         }
         
         
         
         return(finished_chart)
     }
-    public func make_top_row(width: Int) -> String {
+    public func makeTopRow(width: Int) -> String {
         var top_row_bars = ""
         if (width > 0){
             top_row_bars += "┌"
             if (width > 1){
-                for _ in 1...(width - 1) {
-                    top_row_bars += "─┬"
-                }
+                top_row_bars += String(repeating: "─┬", count: width - 1)
+                
             }
             top_row_bars += "─┐"
         }
         top_row_bars += "\n"
         return(top_row_bars)
     }
-    public func make_middle_row(width: Int) -> String {
-        var middle_row_bars = ""
+    public func makeMiddleRow(width: Int) -> String {
+        var middleRowBars = ""
         if (width > 0){
-            middle_row_bars += "├"
+            middleRowBars += "├"
             if (width > 1){
-                for _ in 1...(width - 1) {
-                    middle_row_bars += "─┼"
-                }
+                middleRowBars += String(repeating: "─┼", count: width - 1)
             }
-            middle_row_bars += "─┤"
+            middleRowBars += "─┤"
         }
-        middle_row_bars += "\n"
-        return(middle_row_bars)
+        middleRowBars += "\n"
+        return(middleRowBars)
     }
     
-    public func make_middle_row_stitch_count_change(width: Int, right_difference: Int, left_difference: Int) -> String {
-        
+    public func makeMiddleRowStitchCountChange(width: Int, right_difference: Int, left_difference: Int) -> String {
         
         var middle_row_bars = ""
         if (width > 0){
             middle_row_bars += "├"
             if (right_difference < 0){
-            if (width > 1){
-                for _ in 1...(width) {
-                    middle_row_bars += "─┼"
+                middle_row_bars += String(repeating: "─┼", count: (width))
+                if (abs(right_difference) >= 2){
+                    middle_row_bars += String(repeating: "─┬", count: ((abs(right_difference))-1))
+                    
                 }
-                    if (abs(right_difference) > 1){
-                    for _ in 0...((abs(right_difference))-2){
-                        middle_row_bars += "─┬"
-                    }
-                       
-                    }
                 middle_row_bars += "─┐"
-                }
             }
         }
         middle_row_bars += "\n"
         return(middle_row_bars)
     }
     
-    public func make_bottom_row(width: Int) -> String {
+    
+    
+    public func makeBottomRow(width: Int) -> String {
         var bottom_row_bars = ""
         if (width > 0) {
             bottom_row_bars += "└"
             if (width > 1){
-                for _ in 1...(width - 1) {
-                    bottom_row_bars += "─┴"
-                }
+                bottom_row_bars += String(repeating: "─┴", count: width - 1)
             }
             bottom_row_bars += "─┘"
         }
         return(bottom_row_bars)
     }
     
-    public func make_stitch_row(row: [String]) -> String {
+    public func makeStitchRow(row: [String]) -> String {
         var stitch_row_symbols = ""
         if (row[0] != "" ) {
             stitch_row_symbols += "│"
@@ -126,10 +116,3 @@ public class ChartConstructor {
         return(stitch_row_symbols)
     }
 }
-
-
-//┌─┬─┬─┬─┐
-//│k│p│k│p│
-//├─┼─┼─┼─┤
-//│p│k│p│k│
-//└─┴─┴─┴─┘

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -1,68 +1,60 @@
-
 import Foundation
 
 public class ChartConstructor {
     public init() {}
-    public func make_chart(stitch_array: [[String]]) -> String {
-        
-        let number_of_rows = stitch_array.count
-        var finished_chart = ""
-        let lastrow = number_of_rows - 1
-        
-        for row in 0...lastrow {
-            let row_length = stitch_array[row].count
-            
-            if (row == 0){
-                finished_chart =  makeBottomRow(width: row_length) + finished_chart
-                finished_chart = makeStitchRow(row: stitch_array[row]) + finished_chart
-            }
-            
-            
-            else {
-                let prev_row_length = stitch_array[row - 1].count
-                let right_side_diff = (row_length - prev_row_length)
-                if (right_side_diff < 0){
-                    
-                    finished_chart =  makeMiddleRowStitchCountChange(width: row_length, right_difference: right_side_diff, left_difference: 0) + finished_chart
+    public func makeChart(stitchArray: [[String]]) -> String {
+
+        let numberOfRows = stitchArray.count
+        var finishedChart = ""
+        let lastRow = numberOfRows - 1
+
+        for row in 0...lastRow {
+            let rowLength = stitchArray[row].count
+
+            if row == 0 {
+                finishedChart =  makeBottomRow(width: rowLength) + finishedChart
+                finishedChart = makeStitchRow(row: stitchArray[row]) + finishedChart
+            } else {
+                let prevRowLength = stitchArray[row - 1].count
+                let rightSideDiff = (rowLength - prevRowLength)
+                if rightSideDiff < 0 {
+                    let middleLine = makeMiddleRowStitchCountChange(width: rowLength, rightDifference: rightSideDiff, leftDifference: 0)
+                    finishedChart =  middleLine + finishedChart
+                } else {
+                    finishedChart = makeMiddleRow(width: rowLength) + finishedChart
                 }
-                else {
-                    finished_chart = makeMiddleRow(width: row_length) + finished_chart
-                }
-                
-                finished_chart = makeStitchRow(row: stitch_array[row]) + finished_chart
-                
+
+                finishedChart = makeStitchRow(row: stitchArray[row]) + finishedChart
+
             }
-            
-            
-            if (row == (number_of_rows - 1)){
-                finished_chart = makeTopRow(width: row_length) + finished_chart
-                
+
+            if row == (numberOfRows - 1) {
+                finishedChart = makeTopRow(width: rowLength) + finishedChart
+
             }
-            
+
         }
-        
-        
-        
-        return(finished_chart)
+
+        return(finishedChart)
     }
     public func makeTopRow(width: Int) -> String {
-        var top_row_bars = ""
-        if (width > 0){
-            top_row_bars += "┌"
-            if (width > 1){
-                top_row_bars += String(repeating: "─┬", count: width - 1)
-                
+        var topRowBars = ""
+        if width > 0 {
+            topRowBars += "┌"
+            if width > 1 {
+                topRowBars += String(repeating: "─┬", count: width - 1)
+
             }
-            top_row_bars += "─┐"
+            topRowBars += "─┐"
         }
-        top_row_bars += "\n"
-        return(top_row_bars)
+        topRowBars += "\n"
+        return(topRowBars)
     }
     public func makeMiddleRow(width: Int) -> String {
         var middleRowBars = ""
-        if (width > 0){
+        if width > 0 {
             middleRowBars += "├"
-            if (width > 1){
+            if width > 1 {
                 middleRowBars += String(repeating: "─┼", count: width - 1)
             }
             middleRowBars += "─┤"
@@ -70,49 +62,47 @@ public class ChartConstructor {
         middleRowBars += "\n"
         return(middleRowBars)
     }
-    
-    public func makeMiddleRowStitchCountChange(width: Int, right_difference: Int, left_difference: Int) -> String {
-        
-        var middle_row_bars = ""
-        if (width > 0){
-            middle_row_bars += "├"
-            if (right_difference < 0){
-                middle_row_bars += String(repeating: "─┼", count: (width))
-                if (abs(right_difference) >= 2){
-                    middle_row_bars += String(repeating: "─┬", count: ((abs(right_difference))-1))
-                    
+
+    public func makeMiddleRowStitchCountChange(width: Int, rightDifference: Int, leftDifference: Int) -> String {
+
+        var middleRowBars = ""
+        if width > 0 {
+            middleRowBars += "├"
+            if rightDifference < 0 {
+                middleRowBars += String(repeating: "─┼", count: (width))
+                if abs(rightDifference) >= 2 {
+                    middleRowBars += String(repeating: "─┬", count: ((abs(rightDifference))-1))
+
                 }
-                middle_row_bars += "─┐"
+                middleRowBars += "─┐"
             }
         }
-        middle_row_bars += "\n"
-        return(middle_row_bars)
+        middleRowBars += "\n"
+        return(middleRowBars)
     }
-    
-    
-    
+
     public func makeBottomRow(width: Int) -> String {
-        var bottom_row_bars = ""
-        if (width > 0) {
-            bottom_row_bars += "└"
-            if (width > 1){
-                bottom_row_bars += String(repeating: "─┴", count: width - 1)
+        var bottomRowBars = ""
+        if width > 0 {
+            bottomRowBars += "└"
+            if width > 1 {
+                bottomRowBars += String(repeating: "─┴", count: width - 1)
             }
-            bottom_row_bars += "─┘"
+            bottomRowBars += "─┘"
         }
-        return(bottom_row_bars)
+        return(bottomRowBars)
     }
-    
+
     public func makeStitchRow(row: [String]) -> String {
-        var stitch_row_symbols = ""
-        if (row[0] != "" ) {
-            stitch_row_symbols += "│"
+        var stitchRowSymbols = ""
+        if row[0] != "" {
+            stitchRowSymbols += "│"
             for stitch in row {
-                stitch_row_symbols += stitchPrinting[stitch] ?? ""
-                stitch_row_symbols += "│"
+                stitchRowSymbols += stitchPrinting[stitch] ?? ""
+                stitchRowSymbols += "│"
             }
         }
-        stitch_row_symbols += "\n"
-        return(stitch_row_symbols)
+        stitchRowSymbols += "\n"
+        return(stitchRowSymbols)
     }
 }

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -114,7 +114,7 @@ public class ChartConstructor {
     }
 
     public func makeStitchRow(row: [String]) -> String {
-        let width = row.count
+        var width = row.count
         switch width{
         case 0:
             return "\n"

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -11,6 +11,7 @@ public class ChartConstructor {
         // NEW LOGIC
         for row in 0...lastrow {
             let row_length = stitch_array[row].count
+            
             if (row == 0){
                 finished_chart =  self.make_bottom_row(width: row_length) + finished_chart
                 finished_chart = self.make_stitch_row(row: stitch_array[row]) + finished_chart
@@ -18,9 +19,16 @@ public class ChartConstructor {
             
             
             else {
-
+                let prev_row_length = stitch_array[row - 1].count
+                let right_side_diff = (row_length - prev_row_length)
+                if (right_side_diff < 0){
+                    print("here")
+                    finished_chart =  make_middle_row_stitch_count_change(width: row_length, right_difference: right_side_diff, left_difference: 0) + finished_chart
+                }
+                else {
+                    finished_chart = self.make_middle_row(width: row_length) + finished_chart
+                }
                 
-                finished_chart = self.make_middle_row(width: row_length) + finished_chart
                 finished_chart = self.make_stitch_row(row: stitch_array[row]) + finished_chart
 
                 }
@@ -65,6 +73,32 @@ public class ChartConstructor {
         middle_row_bars += "\n"
         return(middle_row_bars)
     }
+    
+    public func make_middle_row_stitch_count_change(width: Int, right_difference: Int, left_difference: Int) -> String {
+        
+        
+        var middle_row_bars = ""
+        if (width > 0){
+            middle_row_bars += "├"
+            if (right_difference < 0){
+            if (width > 1){
+                for _ in 1...(width) {
+                    middle_row_bars += "─┼"
+                }
+                    if (abs(right_difference) > 1){
+                    for _ in 0...((abs(right_difference))-2){
+                        middle_row_bars += "─┬"
+                    }
+                       
+                    }
+                middle_row_bars += "─┐"
+                }
+            }
+        }
+        middle_row_bars += "\n"
+        return(middle_row_bars)
+    }
+    
     public func make_bottom_row(width: Int) -> String {
         var bottom_row_bars = ""
         if (width > 0) {

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -18,7 +18,7 @@ public class ChartConstructor {
                 let prevRowLength = stitchArray[row - 1].count
                 let rightSideDiff = (rowLength - prevRowLength)
                 if rightSideDiff < 0 {
-                    let middleLine = makeMiddleRowStitchCountChange(width: rowLength, rightDifference: rightSideDiff, leftDifference: 0)
+                    let middleLine = makeMiddleRowStitchCountChange(width: rowLength, rDiff: rightSideDiff, lDiff: 0)
                     finishedChart =  middleLine + finishedChart
                 } else {
                     finishedChart = makeMiddleRow(width: rowLength) + finishedChart
@@ -63,15 +63,15 @@ public class ChartConstructor {
         return(middleRowBars)
     }
 
-    public func makeMiddleRowStitchCountChange(width: Int, rightDifference: Int, leftDifference: Int) -> String {
+    public func makeMiddleRowStitchCountChange(width: Int, rDiff: Int, lDiff: Int) -> String {
 
         var middleRowBars = ""
         if width > 0 {
             middleRowBars += "├"
-            if rightDifference < 0 {
+            if rDiff < 0 {
                 middleRowBars += String(repeating: "─┼", count: (width))
-                if abs(rightDifference) >= 2 {
-                    middleRowBars += String(repeating: "─┬", count: ((abs(rightDifference))-1))
+                if abs(rDiff) >= 2 {
+                    middleRowBars += String(repeating: "─┬", count: ((abs(rDiff))-1))
 
                 }
                 middleRowBars += "─┐"

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -110,7 +110,7 @@ public class ChartConstructor {
         default:
             var middleStitches = ""
             for stitch in row {
-                middleStitches += "\(stitchPrinting[stitch] ?? "")|"
+                middleStitches += "\(stitchPrinting[stitch] ?? "")│"
             }
             return "│\(middleStitches)\n"
         }

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -12,19 +12,22 @@ public class ChartConstructor {
         for row in 0...lastrow {
             let row_length = stitch_array[row].count
             if (row == 0){
-                print("first")
-                finished_chart += self.make_top_row(width: row_length)
-                finished_chart += self.make_stitch_row(row: stitch_array[row])
+                finished_chart =  self.make_bottom_row(width: row_length) + finished_chart
+                finished_chart = self.make_stitch_row(row: stitch_array[row]) + finished_chart
             }
             else {
-                finished_chart += self.make_middle_row(width: row_length)
-                finished_chart += self.make_stitch_row(row: stitch_array[row])
+
                 
+                finished_chart = self.make_middle_row(width: row_length) + finished_chart
+                finished_chart = self.make_stitch_row(row: stitch_array[row]) + finished_chart
+                
+                //if last row
+                if (row == (number_of_rows - 1)){
+                    finished_chart = self.make_top_row(width: row_length) + finished_chart
+                }
+
             }
-            if (row == lastrow){
-                print("last")
-                finished_chart +=  self.make_bottom_row(width: row_length)
-            }
+
         }
         
         

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -15,16 +15,19 @@ public class ChartConstructor {
                 finished_chart =  self.make_bottom_row(width: row_length) + finished_chart
                 finished_chart = self.make_stitch_row(row: stitch_array[row]) + finished_chart
             }
+            
+            
             else {
 
                 
                 finished_chart = self.make_middle_row(width: row_length) + finished_chart
                 finished_chart = self.make_stitch_row(row: stitch_array[row]) + finished_chart
-                
-                //if last row
-                if (row == (number_of_rows - 1)){
-                    finished_chart = self.make_top_row(width: row_length) + finished_chart
+
                 }
+            
+            //if last row
+            if (row == (number_of_rows - 1)){
+                finished_chart = self.make_top_row(width: row_length) + finished_chart
 
             }
 

--- a/Sources/SwiftCliCore/ChartConstructor.swift
+++ b/Sources/SwiftCliCore/ChartConstructor.swift
@@ -38,71 +38,94 @@ public class ChartConstructor {
         return(finishedChart)
     }
     public func makeTopRow(width: Int) -> String {
-        var topRowBars = ""
-        if width > 0 {
-            topRowBars += "┌"
-            if width > 1 {
-                topRowBars += String(repeating: "─┬", count: width - 1)
-
-            }
-            topRowBars += "─┐"
+        switch width {
+        case 0:
+            return "\n"
+        case 1:
+            return "┌─┐\n"
+        default:
+            let middleBoxes = String(repeating: "─┬", count: width - 1)
+            return "┌\(middleBoxes)─┐\n"
         }
-        topRowBars += "\n"
-        return(topRowBars)
+
     }
     public func makeMiddleRow(width: Int) -> String {
-        var middleRowBars = ""
-        if width > 0 {
-            middleRowBars += "├"
-            if width > 1 {
-                middleRowBars += String(repeating: "─┼", count: width - 1)
-            }
-            middleRowBars += "─┤"
+        switch width {
+        case 0:
+            return "\n"
+        case 1:
+            return "├─┤\n"
+        default:
+            let middleBoxes = String(repeating: "─┼", count: width - 1)
+            return "├\(middleBoxes)─┤\n"
         }
-        middleRowBars += "\n"
-        return(middleRowBars)
     }
 
     public func makeMiddleRowStitchCountChange(width: Int, rDiff: Int, lDiff: Int) -> String {
+        var leftStitches = ""
+        var middleStitches = ""
+        var rightStitches = ""
 
-        var middleRowBars = ""
-        if width > 0 {
-            middleRowBars += "├"
-            if rDiff < 0 {
-                middleRowBars += String(repeating: "─┼", count: (width))
-                if abs(rDiff) >= 2 {
-                    middleRowBars += String(repeating: "─┬", count: ((abs(rDiff))-1))
 
-                }
-                middleRowBars += "─┐"
-            }
+        switch lDiff {
+        case 0:
+            leftStitches = "├"
+        default:
+            leftStitches = "├"
         }
-        middleRowBars += "\n"
-        return(middleRowBars)
+
+        switch width {
+        case 1:
+            middleStitches = "─"
+        default:
+            middleStitches = String(repeating: "─┼", count: (width-1))
+        }
+
+
+        switch (true){
+        case (rDiff >= 1):
+            rightStitches = ""
+        case (rDiff == -1):
+            rightStitches = "─┼─┐\n"
+        case (rDiff < -1):
+            let midRightSt = String(repeating: "─┬", count: ((abs(rDiff))-1))
+            rightStitches = "─┼\(midRightSt)─┐\n"
+        default:
+            rightStitches = "─┤\n"
+        }
+
+
+
+        return leftStitches + middleStitches + rightStitches
+
     }
 
     public func makeBottomRow(width: Int) -> String {
-        var bottomRowBars = ""
-        if width > 0 {
-            bottomRowBars += "└"
-            if width > 1 {
-                bottomRowBars += String(repeating: "─┴", count: width - 1)
-            }
-            bottomRowBars += "─┘"
-        }
-        return(bottomRowBars)
+
+        switch width {
+        case 0:
+            return ""
+        case 1:
+            return "└─┘"
+        default:
+            let middleBoxes = String(repeating: "─┴", count: width - 1)
+            return "└\(middleBoxes)─┘"
+    }
     }
 
     public func makeStitchRow(row: [String]) -> String {
-        var stitchRowSymbols = ""
-        if row[0] != "" {
-            stitchRowSymbols += "│"
+        let width = row.count
+        switch width{
+        case 0:
+            return "\n"
+        default:
+            var middleStitches = ""
             for stitch in row {
-                stitchRowSymbols += stitchPrinting[stitch] ?? ""
-                stitchRowSymbols += "│"
+                middleStitches += stitchPrinting[stitch] ?? ""
+                middleStitches += "│"
             }
+            return "│\(middleStitches)\n"
         }
-        stitchRowSymbols += "\n"
-        return(stitchRowSymbols)
+
     }
 }

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -2,21 +2,23 @@ import Foundation
 import ArgumentParser
 // the allowable stitches
 
-
 public final class Chartify {
     public init() {}
     public func run() {
         // Replace this variable with user input
         let input = "g1"
         let isValid = InputValidator().validate(pattern: input)
-        if (isValid == true){
+        if isValid == true {
             let patternArray = InputValidator().arrayMaker(cleanedpattern: input)
-            print(ChartConstructor().make_chart(stitch_array: patternArray))
-        }
-        else{
-            print("Your input was not formatted correctly. Please include only allowed stitches seperated by \\n for line breaks. Current allowed input includes:")
-            for s in allowedStitches{
-                print(s)
+            print(ChartConstructor().makeChart(stitchArray: patternArray))
+        } else {
+            print("""
+                  Your input was not formatted correctly.\
+                  Please include only allowed stitches seperated by \\n for line breaks. \
+ Current allowed input includes:
+""")
+            for stitch in allowedStitches {
+                print(stitch)
             }
         }
     }

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -11,12 +11,12 @@ public final class Chartify {
         let input = "g1"
         let isValid = InputValidator().validate(pattern: input)
         if (isValid == true){
-            let patternArray = InputValidator().ArrayMaker(cleanedpattern: input)
+            let patternArray = InputValidator().arrayMaker(cleanedpattern: input)
             print(ChartConstructor().make_chart(stitch_array: patternArray))
         }
         else{
             print("Your input was not formatted correctly. Please include only allowed stitches seperated by \\n for line breaks. Current allowed input includes:")
-            for s in allowed_stitches{
+            for s in allowedStitches{
                 print(s)
             }
         }

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -6,7 +6,6 @@ import ArgumentParser
 public final class Chartify {
     public init() {}
     public func run() {
-        print("Knitting!")
         // Replace this variable with user input
         let input = "g1"
         let isValid = InputValidator().validate(pattern: input)

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -9,7 +9,7 @@ public final class Chartify {
         let input = "g1"
         let isValid = InputValidator().validate(pattern: input)
         if isValid == true {
-            let patternArray = InputValidator().arrayMaker(cleanedpattern: input)
+            let patternArray = InputValidator().arrayMaker(cleanedPattern: input)
             print(ChartConstructor().makeChart(stitchArray: patternArray))
         } else {
             print("""

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -2,11 +2,3 @@
 
 import Foundation
 
-enum PatternValidationError: Error {
-    case noStitches
-    case invalidStitchFound
-}
-
-enum DeveloperError: Error {
-    case inappropriateInput
-}

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -1,4 +1,1 @@
-
-
 import Foundation
-

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -6,3 +6,7 @@ enum PatternValidationError: Error {
     case noStitches
     case invalidStitchFound
 }
+
+enum DeveloperError: Error {
+    case inappropriateInput
+}

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -1,32 +1,29 @@
-
 import Foundation
 
 // validator class
 public class InputValidator {
     init() {}
-    
+
     // this will validate if the string contains only approved stitches
     public func validate(pattern: String) -> Bool {
-        let pattern_stitches = pattern.split(separator: " ")
-        if pattern_stitches.count == 0 {
+        let patternStitches = pattern.split(separator: " ")
+        if patternStitches.count == 0 {
             return false
         }
-        let isItValid = pattern_stitches.allSatisfy({ allowedStitches.contains(String($0)) })
+        let isItValid = patternStitches.allSatisfy({ allowedStitches.contains(String($0)) })
         return isItValid
     }
-    
-    
-    
+
     public func arrayMaker(cleanedpattern: String) -> [[String]] {
         var stitchArray: [[String]] = []
         let patternRows = cleanedpattern.split(separator: "\n")
-        for row in patternRows{
+        for row in patternRows {
             let substringPatternStitches = row.split(separator: " ")
-            let patternStitches = substringPatternStitches.map{(String($0))}
-            if (patternStitches.count > 0){
+            let patternStitches = substringPatternStitches.map {(String($0))}
+            if patternStitches.count > 0 {
                 stitchArray.append(patternStitches)}
         }
         return(stitchArray)
     }
-    
+
 }

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -11,36 +11,22 @@ public class InputValidator {
         if pattern_stitches.count == 0 {
             return false
         }
-        let isItValid = pattern_stitches.allSatisfy({ allowed_stitches.contains(String($0)) })
+        let isItValid = pattern_stitches.allSatisfy({ allowedStitches.contains(String($0)) })
         return isItValid
     }
     
-
-    public func FindWidestRow(patternarray: [[String]]) -> Int {
-        var widest = -1;
-        
-        for row in (0...(patternarray.count - 1)){
-            if (patternarray[row].count > widest) {
-                widest = row
-            }
+    
+    
+    public func arrayMaker(cleanedpattern: String) -> [[String]] {
+        var stitchArray: [[String]] = []
+        let patternRows = cleanedpattern.split(separator: "\n")
+        for row in patternRows{
+            let substringPatternStitches = row.split(separator: " ")
+            let patternStitches = substringPatternStitches.map{(String($0))}
+            if (patternStitches.count > 0){
+                stitchArray.append(patternStitches)}
         }
-        
-        return widest;
+        return(stitchArray)
     }
     
-    
-    public func ArrayMaker(cleanedpattern: String) -> [[String]] {
-        var stitch_array: [[String]] = []
-        let pattern_rows = cleanedpattern.split(separator: "\n")
-        for row in pattern_rows{
-            var substring_pattern_stitches = row.split(separator: " ")
-            var pattern_stitches = substring_pattern_stitches.map{(String($0))}
-            if (pattern_stitches.count > 0){
-                stitch_array.append(pattern_stitches)}
-        }
-        return(stitch_array)
-    }
-    
-    public func CenteredArrayMaker(array: [[String]]) -> [[String]] {
-        return array}
 }

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -15,6 +15,20 @@ public class InputValidator {
         return isItValid
     }
     
+
+    public func FindWidestRow(patternarray: [[String]]) -> Int {
+        var widest = -1;
+        
+        for row in (0...(patternarray.count - 1)){
+            if (patternarray[row].count > widest) {
+                widest = row
+            }
+        }
+        
+        return widest;
+    }
+    
+    
     public func ArrayMaker(cleanedpattern: String) -> [[String]] {
         var stitch_array: [[String]] = []
         let pattern_rows = cleanedpattern.split(separator: "\n")
@@ -26,4 +40,7 @@ public class InputValidator {
         }
         return(stitch_array)
     }
+    
+    public func CenteredArrayMaker(array: [[String]]) -> [[String]] {
+        return array}
 }

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -14,9 +14,9 @@ public class InputValidator {
         return isItValid
     }
 
-    public func arrayMaker(cleanedpattern: String) -> [[String]] {
+    public func arrayMaker(cleanedPattern: String) -> [[String]] {
         var stitchArray: [[String]] = []
-        let patternRows = cleanedpattern.split(separator: "\n")
+        let patternRows = cleanedPattern.split(separator: "\n")
         for row in patternRows {
             let substringPatternStitches = row.split(separator: " ")
             let patternStitches = substringPatternStitches.map {(String($0))}

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-let allowed_stitches = ["k1", "p1",  "ssk", "k2tog", "yo", "m1", "\n"]
+let allowedStitches = ["k1", "p1",  "ssk", "k2tog", "yo", "m1", "\n"]
 let stitchPrinting = ["k1":" ",
                       "p1":"-",
                       "ssk":"\\",
@@ -10,13 +10,3 @@ let stitchPrinting = ["k1":" ",
                       "m1":"m",]
 
 
-public func arrayCompare(array1: [[String]], array2: [[String]]) -> Bool {
-    var IsItTheSame : Bool! = nil
-    if (array1 == array2){
-        IsItTheSame = true
-    }
-    else{
-        IsItTheSame = false
-    }
-    return IsItTheSame
-}

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -1,12 +1,9 @@
-
 import Foundation
 
-let allowedStitches = ["k1", "p1",  "ssk", "k2tog", "yo", "m1", "\n"]
-let stitchPrinting = ["k1":" ",
-                      "p1":"-",
-                      "ssk":"\\",
-                      "k2tog":"/",
-                      "yo":"o",
-                      "m1":"m",]
-
-
+let allowedStitches = ["k1", "p1", "ssk", "k2tog", "yo", "m1", "\n"]
+let stitchPrinting = ["k1": " ",
+                      "p1": "-",
+                      "ssk": "\\",
+                      "k2tog": "/",
+                      "yo": "o",
+                      "m1": "m" ]

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-let allowed_stitches = ["k1", "p1", "\n", "ssk", "k2tog", "yo", "m1"]
+let allowed_stitches = ["k1", "p1",  "ssk", "k2tog", "yo", "m1", "\n"]
 let stitchPrinting = ["k1":" ",
                       "p1":"-",
                       "ssk":"\\",

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -1,6 +1,22 @@
 
 import Foundation
 
-let allowed_stitches = ["k1", "p1", "\n"]
+let allowed_stitches = ["k1", "p1", "\n", "ssk", "k2tog", "yo", "m1"]
 let stitchPrinting = ["k1":" ",
-                      "p1":"-"]
+                      "p1":"-",
+                      "ssk":"\\",
+                      "k2tog":"/",
+                      "yo":"o",
+                      "m1":"m",]
+
+
+public func arrayCompare(array1: [[String]], array2: [[String]]) -> Bool {
+    var IsItTheSame : Bool! = nil
+    if (array1 == array2){
+        IsItTheSame = true
+    }
+    else{
+        IsItTheSame = false
+    }
+    return IsItTheSame
+}

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -119,45 +119,45 @@ class FullChartPrinterTests: XCTestCase {
 """
         XCTAssertEqual(result, expectedresult)
     }
-    
-        func testFullPatternLeftK2togDecrease() throws {
-            let result = ChartConstructor().make_chart(stitch_array: [["k2tog", "k1", "p1", "p1", "k1", "k1"],["k1", "p1", "p1", "k1", "k1"]])
-            let expectedresult = """
-      ┌─┬─┬─┬─┬─┐
-      │ │-│-│ │ │
-    ┌─┼─┼─┼─┼─┼─┤
-    │/│ │-│-│ │ │
-    └─┴─┴─┴─┴─┴─┘
-    """
-            XCTAssertEqual(result, expectedresult)
-        }
-    
-    func testFullPatternRight9YODecrease() throws {
-        let result = ChartConstructor().make_chart(stitch_array: [["k1", "p1", "k1", "yo"],["k1", "p1", "k1", "k1", "k1"]])
-        let expectedresult = """
-┌─┬─┬─┬─┬─┐
-│ │-│ │ │ │
-├─┼─┼─┼─┼─┘
-│ │-│ │o│
-└─┴─┴─┴─┘
-"""
-        XCTAssertEqual(result, expectedresult)
-    }
-    
-    func testIncreaseAndDecrease() throws {
-        let result = ChartConstructor().make_chart(stitch_array: [["k2tog", "k1", "k1", "k1", "ssk"],["k2tog", "k1", "ssk"], ["k1"]])
-        let expectedresult = """
-    ┌─┐
-    │ │
-  ┌─┼─┼─┐
-  │/│ │\\│
-┌─┼─┼─┼─┤─┐
-│/│ │ │ │\\│
-└─┴─┴─┴─┴─┘
-"""
-        XCTAssertEqual(result, expectedresult)
-    }
-    
+//
+//        func testFullPatternLeftK2togDecrease() throws {
+//            let result = ChartConstructor().make_chart(stitch_array: [["k2tog", "k1", "p1", "p1", "k1", "k1"],["k1", "p1", "p1", "k1", "k1"]])
+//            let expectedresult = """
+//      ┌─┬─┬─┬─┬─┐
+//      │ │-│-│ │ │
+//    ┌─┼─┼─┼─┼─┼─┤
+//    │/│ │-│-│ │ │
+//    └─┴─┴─┴─┴─┴─┘
+//    """
+//            XCTAssertEqual(result, expectedresult)
+//        }
+//
+//    func testFullPatternRight9YODecrease() throws {
+//        let result = ChartConstructor().make_chart(stitch_array: [["k1", "p1", "k1", "yo"],["k1", "p1", "k1", "k1", "k1"]])
+//        let expectedresult = """
+//┌─┬─┬─┬─┬─┐
+//│ │-│ │ │ │
+//├─┼─┼─┼─┼─┘
+//│ │-│ │o│
+//└─┴─┴─┴─┘
+//"""
+//        XCTAssertEqual(result, expectedresult)
+//    }
+//
+//    func testIncreaseAndDecrease() throws {
+//        let result = ChartConstructor().make_chart(stitch_array: [["k2tog", "k1", "k1", "k1", "ssk"],["k2tog", "k1", "ssk"], ["k1"]])
+//        let expectedresult = """
+//    ┌─┐
+//    │ │
+//  ┌─┼─┼─┐
+//  │/│ │\\│
+//┌─┼─┼─┼─┤─┐
+//│/│ │ │ │\\│
+//└─┴─┴─┴─┴─┘
+//"""
+//        XCTAssertEqual(result, expectedresult)
+//    }
+//
     
     
 }

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -95,14 +95,70 @@ class FullChartPrinterTests: XCTestCase {
         XCTAssertEqual(result, expectedresult)
     }
     func testFullPatternTwoRow() throws {
-        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1"],["k1", "k1", "p1", "p1", "k1", "k1"]])
+        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1"],["p1", "p1", "k1", "k1", "p1", "p1"]])
         let expectedresult = """
 ┌─┬─┬─┬─┬─┬─┐
-│ │ │-│-│ │ │
+│-│-│ │ │-│-│
 ├─┼─┼─┼─┼─┼─┤
 │ │ │-│-│ │ │
 └─┴─┴─┴─┴─┴─┘
 """
         XCTAssertEqual(result, expectedresult)
     }
+    
+    func testFullPatternRightSSKDecrease() throws {
+        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "ssk"],["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],["k1", "k1", "p1", "p1", "k1", "k1"]])
+        let expectedresult = """
+┌─┬─┬─┬─┬─┬─┐
+│ │ │-│-│ │ │
+├─┼─┼─┼─┼─┼─┤─┐
+│ │ │-│-│ │ │\\│
+├─┼─┼─┼─┼─┼─┼─┤─┐
+│ │ │-│-│ │ │-│\\│
+└─┴─┴─┴─┴─┴─┴─┴─┘
+"""
+        XCTAssertEqual(result, expectedresult)
+    }
+    
+        func testFullPatternLeftK2togDecrease() throws {
+            let result = ChartConstructor().make_chart(stitch_array: [["k2tog", "k1", "p1", "p1", "k1", "k1"],["k1", "p1", "p1", "k1", "k1"]])
+            let expectedresult = """
+      ┌─┬─┬─┬─┬─┐
+      │ │-│-│ │ │
+    ┌─┼─┼─┼─┼─┼─┤
+    │/│ │-│-│ │ │
+    └─┴─┴─┴─┴─┴─┘
+    """
+            XCTAssertEqual(result, expectedresult)
+        }
+    
+    func testFullPatternRight9YODecrease() throws {
+        let result = ChartConstructor().make_chart(stitch_array: [["k1", "p1", "k1", "yo"],["k1", "p1", "k1", "k1", "k1"]])
+        let expectedresult = """
+┌─┬─┬─┬─┬─┐
+│ │-│ │ │ │
+├─┼─┼─┼─┼─┘
+│ │-│ │o│
+└─┴─┴─┴─┘
+"""
+        XCTAssertEqual(result, expectedresult)
+    }
+    
+    func testIncreaseAndDecrease() throws {
+        let result = ChartConstructor().make_chart(stitch_array: [["k2tog", "k1", "k1", "k1", "ssk"],["k2tog", "k1", "ssk"], ["k1"]])
+        let expectedresult = """
+    ┌─┐
+    │ │
+  ┌─┼─┼─┐
+  │/│ │\\│
+┌─┼─┼─┼─┤─┐
+│/│ │ │ │\\│
+└─┴─┴─┴─┴─┘
+"""
+        XCTAssertEqual(result, expectedresult)
+    }
+    
+    
+    
 }
+

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -6,15 +6,21 @@ import Nimble
 class TopLevelPrinterTests: XCTestCase {
 
     func testPrintTopLevelMany() throws {
-        expect(ChartConstructor().makeTopRow(width: 4))=="┌─┬─┬─┬─┐\n"
+        let result = ChartConstructor().makeTopRow(width: 4)
+        let expectedOutput = "┌─┬─┬─┬─┐\n"
+        expect(result).to(equal(expectedOutput))
     }
 
     func testPrintTopLevelOne() throws {
-        expect(ChartConstructor().makeTopRow(width: 1))=="┌─┐\n"
+        let result = ChartConstructor().makeTopRow(width: 1)
+        let expectedOutput = "┌─┐\n"
+        expect(result).to(equal(expectedOutput))
     }
 
     func testPrintTopLevelZero() throws {
-        expect(ChartConstructor().makeTopRow(width: 0))=="\n"
+        let result = ChartConstructor().makeTopRow(width: 0)
+        let expectedOutput = "\n"
+        expect(result).to(equal(expectedOutput))
     }
 
 }
@@ -22,57 +28,78 @@ class BottomLevelPrinterTests: XCTestCase {
 
     // Bottom Level Tests
     func testPrintBottomLevelMany() throws {
-        expect(ChartConstructor().makeBottomRow(width: 4))=="└─┴─┴─┴─┘"
+        let result = ChartConstructor().makeBottomRow(width: 4)
+        let expectedOutput = "└─┴─┴─┴─┘"
+        expect(result).to(equal(expectedOutput))
     }
 
     func testPrintBottomLevelOne() throws {
-        expect(ChartConstructor().makeBottomRow(width: 1))=="└─┘"
+        let result = ChartConstructor().makeBottomRow(width: 1)
+        let expectedOutput = "└─┘"
+        expect(result).to(equal(expectedOutput))
     }
 
     func testPrintBottomLevelZero() throws {
-        expect(ChartConstructor().makeBottomRow(width: 0))==""
+        let result = ChartConstructor().makeBottomRow(width: 0)
+        let expectedOutput = ""
+        expect(result).to(equal(expectedOutput))
     }
 }
 class MiddleLevelPrinterTests: XCTestCase {
 
     func testPrintMiddleLevelMany() throws {
-        expect(ChartConstructor().makeMiddleRow(width: 4))=="├─┼─┼─┼─┤\n"
+        let result = ChartConstructor().makeMiddleRow(width: 4)
+        let expectedOutput = "├─┼─┼─┼─┤\n"
+        expect(result).to(equal(expectedOutput))
     }
 
     func testPrintMiddleLevelOne() throws {
-        expect(ChartConstructor().makeMiddleRow(width: 1))=="├─┤\n"
+        let result = ChartConstructor().makeMiddleRow(width: 1)
+        let expectedOutput = "├─┤\n"
+        expect(result).to(equal(expectedOutput))
     }
 
     func testPrintMiddleLevelZero() throws {
-        expect(ChartConstructor().makeMiddleRow(width: 0))=="\n"
+        let result = ChartConstructor().makeMiddleRow(width: 0)
+        let expectedOutput = "\n"
+        expect(result).to(equal(expectedOutput))
     }
 
 }
 class StitchRowPrinterTests: XCTestCase {
 
     func testPrintStitchRowMany() throws {
-        expect(ChartConstructor().makeStitchRow(row: ["k1", "k1", "p1", "p1", "k1", "k1"]))=="│ │ │-│-│ │ │\n"
+        let result = ChartConstructor().makeStitchRow(row: ["k1", "k1", "p1", "p1", "k1", "k1"])
+        let expectedOutput = "│ │ │-│-│ │ │\n"
+        expect(result).to(equal(expectedOutput))
     }
 
     func testPrintStitchRowOne() throws {
-        expect(ChartConstructor().makeStitchRow(row: ["k1"]))=="│ │\n"
+        let result = ChartConstructor().makeStitchRow(row: ["k1"])
+        let expectedOutput = "│ │\n"
+        expect(result).to(equal(expectedOutput))
     }
 
 }
 
 class RightDecreaseMiddlePrinterTests: XCTestCase {
     func testOneRightDecrease() throws {
-        expect(ChartConstructor().makeMiddleRowStitchCountChange(width: 6, rDiff: -1, lDiff: 0))=="├─┼─┼─┼─┼─┼─┼─┐\n"
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 6, rDiff: -1, lDiff: 0)
+        let expectedOutput = "├─┼─┼─┼─┼─┼─┼─┐\n"
+        expect(result).to(equal(expectedOutput))
 
     }
 
     func testThreeRightDecrease() throws {
-        expect(ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -3, lDiff: 0))=="├─┼─┼─┼─┬─┬─┐\n"
-
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -3, lDiff: 0)
+        let expectedOutput = "├─┼─┼─┼─┬─┬─┐\n"
+        expect(result).to(equal(expectedOutput))
     }
 
     func testTwoRightDecrease() throws {
-        expect(ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -2, lDiff: 0))=="├─┼─┼─┼─┬─┐\n"
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -2, lDiff: 0)
+        let expectedOutput = "├─┼─┼─┼─┬─┐\n"
+        expect(result).to(equal(expectedOutput))
 
     }
 
@@ -82,29 +109,34 @@ class FullChartPrinterTests: XCTestCase {
     // Full Chart Tests
 
     func testFullPatternOneRow() throws {
-        expect(ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"]]))=="""
+        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"]])
+        let expectedOutput = """
 ┌─┬─┬─┬─┬─┬─┐
 │ │ │-│-│ │ │
 └─┴─┴─┴─┴─┴─┘
 """
+        expect(result).to(equal(expectedOutput))
 
     }
     func testFullPatternTwoRow() throws {
-        expect(ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"],
-                                                          ["p1", "p1", "k1", "k1", "p1", "p1"]]))=="""
+        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"],
+                                                                ["p1", "p1", "k1", "k1", "p1", "p1"]])
+        let expectedOutput = """
 ┌─┬─┬─┬─┬─┬─┐
 │-│-│ │ │-│-│
 ├─┼─┼─┼─┼─┼─┤
 │ │ │-│-│ │ │
 └─┴─┴─┴─┴─┴─┘
 """
+        expect(result).to(equal(expectedOutput))
 
     }
 
     func testFullPatternRightSSKDecrease() throws {
-        expect(ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "k1"],
-                                                          ["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],
-                                                          ["k1", "k1", "p1", "p1", "k1", "ssk"]]))=="""
+        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "k1"],
+                                                                ["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],
+                                                                ["k1", "k1", "p1", "p1", "k1", "ssk"]])
+        let expectedOutput = """
 ┌─┬─┬─┬─┬─┬─┐
 │ │ │-│-│ │\\│
 ├─┼─┼─┼─┼─┼─┼─┐
@@ -113,17 +145,20 @@ class FullChartPrinterTests: XCTestCase {
 │ │ │-│-│ │ │-│ │
 └─┴─┴─┴─┴─┴─┴─┴─┘
 """
+        expect(result).to(equal(expectedOutput))
     }
 
     func testFullPatternTripleRightSSKDecrease() throws {
-        expect(ChartConstructor().makeChart(stitchArray: [["k1", "k1", "k1", "k1", "k1", "k1", "k1", "k1"],
-                                                                ["k1", "k1", "ssk", "ssk", "ssk"]])) == """
+        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "k1", "k1", "k1", "k1", "k1", "k1"],
+                                                                ["k1", "k1", "ssk", "ssk", "ssk"]])
+        let expectedOutput = """
 ┌─┬─┬─┬─┬─┐
 │ │ │\\│\\│\\│
 ├─┼─┼─┼─┼─┼─┬─┬─┐
 │ │ │ │ │ │ │ │ │
 └─┴─┴─┴─┴─┴─┴─┴─┘
 """
+        expect(result).to(equal(expectedOutput))
 
     }
 

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -7,17 +7,17 @@ class TopLevelPrinterTests: XCTestCase {
     
     // Top Level Tests
     func testPrintTopLevelMany() throws {
-        let result = ChartConstructor().make_top_row(width: 4)
+        let result = ChartConstructor().makeTopRow(width: 4)
         XCTAssertEqual(result, "┌─┬─┬─┬─┐\n")
     }
     
     func testPrintTopLevelOne() throws {
-        let result = ChartConstructor().make_top_row(width: 1)
+        let result = ChartConstructor().makeTopRow(width: 1)
         XCTAssertEqual(result, "┌─┐\n")
     }
     
     func testPrintTopLevelZero() throws {
-        let result = ChartConstructor().make_top_row(width: 0)
+        let result = ChartConstructor().makeTopRow(width: 0)
         XCTAssertEqual(result, "\n")
     }
     
@@ -27,17 +27,17 @@ class BottomLevelPrinterTests: XCTestCase {
     
     // Bottom Level Tests
     func testPrintBottomLevelMany() throws {
-        let result = ChartConstructor().make_bottom_row(width: 4)
+        let result = ChartConstructor().makeBottomRow(width: 4)
         XCTAssertEqual(result, "└─┴─┴─┴─┘")
     }
     
     func testPrintBottomLevelOne() throws {
-        let result = ChartConstructor().make_bottom_row(width: 1)
+        let result = ChartConstructor().makeBottomRow(width: 1)
         XCTAssertEqual(result, "└─┘")
     }
     
     func testPrintBottomLevelZero() throws {
-        let result = ChartConstructor().make_bottom_row(width: 0)
+        let result = ChartConstructor().makeBottomRow(width: 0)
         XCTAssertEqual(result, "")
     }
 }
@@ -46,17 +46,17 @@ class MiddleLevelPrinterTests: XCTestCase {
     // Middle-of-Rows Tests
     
     func testPrintMiddleLevelMany() throws {
-        let result = ChartConstructor().make_middle_row(width: 4)
+        let result = ChartConstructor().makeMiddleRow(width: 4)
         XCTAssertEqual(result, "├─┼─┼─┼─┤\n")
     }
     
     func testPrintMiddleLevelOne() throws {
-        let result = ChartConstructor().make_middle_row(width: 1)
+        let result = ChartConstructor().makeMiddleRow(width: 1)
         XCTAssertEqual(result, "├─┤\n")
     }
     
     func testPrintMiddleLevelZero() throws {
-        let result = ChartConstructor().make_middle_row(width: 0)
+        let result = ChartConstructor().makeMiddleRow(width: 0)
         XCTAssertEqual(result, "\n")
     }
     
@@ -66,17 +66,17 @@ class StitchRowPrinterTests: XCTestCase {
     
     
     func testPrintStitchRowMany() throws {
-        let result = ChartConstructor().make_stitch_row(row: ["k1", "k1", "p1", "p1", "k1", "k1"])
+        let result = ChartConstructor().makeStitchRow(row: ["k1", "k1", "p1", "p1", "k1", "k1"])
         XCTAssertEqual(result, "│ │ │-│-│ │ │\n")
     }
     
     func testPrintStitchRowOne() throws {
-        let result = ChartConstructor().make_stitch_row(row: ["k1"])
+        let result = ChartConstructor().makeStitchRow(row: ["k1"])
         XCTAssertEqual(result, "│ │\n")
     }
     
     func testPrintStitchRowZero() throws {
-        let result = ChartConstructor().make_stitch_row(row: [""])
+        let result = ChartConstructor().makeStitchRow(row: [""])
         XCTAssertEqual(result, "\n")
     }
     
@@ -85,19 +85,25 @@ class StitchRowPrinterTests: XCTestCase {
 
 class RightDecreaseMiddlePrinterTests: XCTestCase {
     func testOneRightDecrease() throws {
-    let result = ChartConstructor().make_middle_row_stitch_count_change(width: 6, right_difference: -1, left_difference: 0)
-    let expected = "├─┼─┼─┼─┼─┼─┼─┐\n"
-        XCTAssertEqual(result, expected)}
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 6, right_difference: -1, left_difference: 0)
+        let expected = "├─┼─┼─┼─┼─┼─┼─┐\n"
+        XCTAssertEqual(result, expected)
+        
+    }
     
     func testThreeRightDecrease() throws {
-    let result = ChartConstructor().make_middle_row_stitch_count_change(width: 3, right_difference: -3, left_difference: 0)
-    let expected = "├─┼─┼─┼─┬─┬─┐\n"
-        XCTAssertEqual(result, expected)}
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, right_difference: -3, left_difference: 0)
+        let expected = "├─┼─┼─┼─┬─┬─┐\n"
+        XCTAssertEqual(result, expected)
+        
+    }
     
     func testTwoRightDecrease() throws {
-    let result = ChartConstructor().make_middle_row_stitch_count_change(width: 3, right_difference: -2, left_difference: 0)
-    let expected = "├─┼─┼─┼─┬─┐\n"
-        XCTAssertEqual(result, expected)}
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, right_difference: -2, left_difference: 0)
+        let expected = "├─┼─┼─┼─┬─┐\n"
+        XCTAssertEqual(result, expected)
+        
+    }
     
 }
 
@@ -155,45 +161,6 @@ class FullChartPrinterTests: XCTestCase {
 """
         XCTAssertEqual(result, expectedresult)
     }
-//
-//        func testFullPatternLeftK2togDecrease() throws {
-//            let result = ChartConstructor().make_chart(stitch_array: [["k2tog", "k1", "p1", "p1", "k1", "k1"],["k1", "p1", "p1", "k1", "k1"]])
-//            let expectedresult = """
-//      ┌─┬─┬─┬─┬─┐
-//      │ │-│-│ │ │
-//    ┌─┼─┼─┼─┼─┼─┤
-//    │/│ │-│-│ │ │
-//    └─┴─┴─┴─┴─┴─┘
-//    """
-//            XCTAssertEqual(result, expectedresult)
-//        }
-//
-//    func testFullPatternRight9YODecrease() throws {
-//        let result = ChartConstructor().make_chart(stitch_array: [["k1", "p1", "k1", "yo"],["k1", "p1", "k1", "k1", "k1"]])
-//        let expectedresult = """
-//┌─┬─┬─┬─┬─┐
-//│ │-│ │ │ │
-//├─┼─┼─┼─┼─┘
-//│ │-│ │o│
-//└─┴─┴─┴─┘
-//"""
-//        XCTAssertEqual(result, expectedresult)
-//    }
-//
-//    func testIncreaseAndDecrease() throws {
-//        let result = ChartConstructor().make_chart(stitch_array: [["k2tog", "k1", "k1", "k1", "ssk"],["k2tog", "k1", "ssk"], ["k1"]])
-//        let expectedresult = """
-//    ┌─┐
-//    │ │
-//  ┌─┼─┼─┐
-//  │/│ │\\│
-//┌─┼─┼─┼─┤─┐
-//│/│ │ │ │\\│
-//└─┴─┴─┴─┴─┘
-//"""
-//        XCTAssertEqual(result, expectedresult)
-//    }
-//
     
     
 }

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -58,9 +58,6 @@ class StitchRowPrinterTests: XCTestCase {
         expect(ChartConstructor().makeStitchRow(row: ["k1"]))=="│ │\n"
     }
 
-    func testPrintStitchRowZero() throws {
-        expect(ChartConstructor().makeStitchRow(row: [""]))=="\n"
-    }
 
 }
 

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -58,7 +58,6 @@ class StitchRowPrinterTests: XCTestCase {
         expect(ChartConstructor().makeStitchRow(row: ["k1"]))=="│ │\n"
     }
 
-
 }
 
 class RightDecreaseMiddlePrinterTests: XCTestCase {
@@ -69,7 +68,6 @@ class RightDecreaseMiddlePrinterTests: XCTestCase {
 
     func testThreeRightDecrease() throws {
         expect(ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -3, lDiff: 0))=="├─┼─┼─┼─┬─┬─┐\n"
-
 
     }
 

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -2,119 +2,112 @@ import Foundation
 import XCTest
 @testable import SwiftCliCore
 
-
 class TopLevelPrinterTests: XCTestCase {
-    
+
     // Top Level Tests
     func testPrintTopLevelMany() throws {
         let result = ChartConstructor().makeTopRow(width: 4)
         XCTAssertEqual(result, "┌─┬─┬─┬─┐\n")
     }
-    
+
     func testPrintTopLevelOne() throws {
         let result = ChartConstructor().makeTopRow(width: 1)
         XCTAssertEqual(result, "┌─┐\n")
     }
-    
+
     func testPrintTopLevelZero() throws {
         let result = ChartConstructor().makeTopRow(width: 0)
         XCTAssertEqual(result, "\n")
     }
-    
-    
+
 }
 class BottomLevelPrinterTests: XCTestCase {
-    
+
     // Bottom Level Tests
     func testPrintBottomLevelMany() throws {
         let result = ChartConstructor().makeBottomRow(width: 4)
         XCTAssertEqual(result, "└─┴─┴─┴─┘")
     }
-    
+
     func testPrintBottomLevelOne() throws {
         let result = ChartConstructor().makeBottomRow(width: 1)
         XCTAssertEqual(result, "└─┘")
     }
-    
+
     func testPrintBottomLevelZero() throws {
         let result = ChartConstructor().makeBottomRow(width: 0)
         XCTAssertEqual(result, "")
     }
 }
 class MiddleLevelPrinterTests: XCTestCase {
-    
+
     // Middle-of-Rows Tests
-    
+
     func testPrintMiddleLevelMany() throws {
         let result = ChartConstructor().makeMiddleRow(width: 4)
         XCTAssertEqual(result, "├─┼─┼─┼─┤\n")
     }
-    
+
     func testPrintMiddleLevelOne() throws {
         let result = ChartConstructor().makeMiddleRow(width: 1)
         XCTAssertEqual(result, "├─┤\n")
     }
-    
+
     func testPrintMiddleLevelZero() throws {
         let result = ChartConstructor().makeMiddleRow(width: 0)
         XCTAssertEqual(result, "\n")
     }
-    
+
 }
 class StitchRowPrinterTests: XCTestCase {
     // Stitch Row Tests
-    
-    
+
     func testPrintStitchRowMany() throws {
         let result = ChartConstructor().makeStitchRow(row: ["k1", "k1", "p1", "p1", "k1", "k1"])
         XCTAssertEqual(result, "│ │ │-│-│ │ │\n")
     }
-    
+
     func testPrintStitchRowOne() throws {
         let result = ChartConstructor().makeStitchRow(row: ["k1"])
         XCTAssertEqual(result, "│ │\n")
     }
-    
+
     func testPrintStitchRowZero() throws {
         let result = ChartConstructor().makeStitchRow(row: [""])
         XCTAssertEqual(result, "\n")
     }
-    
-    
+
 }
 
 class RightDecreaseMiddlePrinterTests: XCTestCase {
     func testOneRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 6, right_difference: -1, left_difference: 0)
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 6, rightDifference: -1, leftDifference: 0)
         let expected = "├─┼─┼─┼─┼─┼─┼─┐\n"
         XCTAssertEqual(result, expected)
-        
+
     }
-    
+
     func testThreeRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, right_difference: -3, left_difference: 0)
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rightDifference: -3, leftDifference: 0)
         let expected = "├─┼─┼─┼─┬─┬─┐\n"
         XCTAssertEqual(result, expected)
-        
+
     }
-    
+
     func testTwoRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, right_difference: -2, left_difference: 0)
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rightDifference: -2, leftDifference: 0)
         let expected = "├─┼─┼─┼─┬─┐\n"
         XCTAssertEqual(result, expected)
-        
+
     }
-    
+
 }
-
-
-
 
 class FullChartPrinterTests: XCTestCase {
     // Full Chart Tests
-    
+
     func testFullPatternOneRow() throws {
-        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1"]])
+        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"]])
         let expectedresult = """
 ┌─┬─┬─┬─┬─┬─┐
 │ │ │-│-│ │ │
@@ -123,7 +116,8 @@ class FullChartPrinterTests: XCTestCase {
         XCTAssertEqual(result, expectedresult)
     }
     func testFullPatternTwoRow() throws {
-        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1"],["p1", "p1", "k1", "k1", "p1", "p1"]])
+        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"],
+                                                                ["p1", "p1", "k1", "k1", "p1", "p1"]])
         let expectedresult = """
 ┌─┬─┬─┬─┬─┬─┐
 │-│-│ │ │-│-│
@@ -133,9 +127,11 @@ class FullChartPrinterTests: XCTestCase {
 """
         XCTAssertEqual(result, expectedresult)
     }
-    
+
     func testFullPatternRightSSKDecrease() throws {
-        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "k1"],["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],["k1", "k1", "p1", "p1", "k1", "ssk"]])
+        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "k1"],
+                                                                ["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],
+                                                                ["k1", "k1", "p1", "p1", "k1", "ssk"]])
         let expectedresult = """
 ┌─┬─┬─┬─┬─┬─┐
 │ │ │-│-│ │\\│
@@ -147,21 +143,18 @@ class FullChartPrinterTests: XCTestCase {
 """
         XCTAssertEqual(result, expectedresult)
     }
-    
-    
-    
+
     func testFullPatternTripleRightSSKDecrease() throws {
-        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1","k1", "k1","k1", "k1"],["k1", "k1", "p1", "p1", "ssk", "ssk", "ssk"]])
+        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "k1", "k1", "k1", "k1", "k1", "k1"],
+                                                                ["k1", "k1", "ssk", "ssk", "ssk"]])
         let expectedresult = """
-┌─┬─┬─┬─┬─┬─┬─┐
-│ │ │-│-│\\│\\│\\│
-├─┼─┼─┼─┼─┼─┼─┼─┬─┬─┐
-│ │ │-│-│ │ │ │ │ │ │
-└─┴─┴─┴─┴─┴─┴─┴─┴─┴─┘
+┌─┬─┬─┬─┬─┐
+│ │ │\\│\\│\\│
+├─┼─┼─┼─┼─┼─┬─┬─┐
+│ │ │ │ │ │ │ │ │
+└─┴─┴─┴─┴─┴─┴─┴─┘
 """
         XCTAssertEqual(result, expectedresult)
     }
-    
-    
-}
 
+}

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -81,21 +81,21 @@ class StitchRowPrinterTests: XCTestCase {
 
 class RightDecreaseMiddlePrinterTests: XCTestCase {
     func testOneRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 6, rightDifference: -1, leftDifference: 0)
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 6, rDiff: -1, lDiff: 0)
         let expected = "├─┼─┼─┼─┼─┼─┼─┐\n"
         XCTAssertEqual(result, expected)
 
     }
 
     func testThreeRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rightDifference: -3, leftDifference: 0)
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -3, lDiff: 0)
         let expected = "├─┼─┼─┼─┬─┬─┐\n"
         XCTAssertEqual(result, expected)
 
     }
 
     func testTwoRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rightDifference: -2, leftDifference: 0)
+        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -2, lDiff: 0)
         let expected = "├─┼─┼─┼─┬─┐\n"
         XCTAssertEqual(result, expected)
 

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -82,6 +82,28 @@ class StitchRowPrinterTests: XCTestCase {
     
     
 }
+
+class RightDecreaseMiddlePrinterTests: XCTestCase {
+    func testOneRightDecrease() throws {
+    let result = ChartConstructor().make_middle_row_stitch_count_change(width: 6, right_difference: -1, left_difference: 0)
+    let expected = "├─┼─┼─┼─┼─┼─┼─┐\n"
+        XCTAssertEqual(result, expected)}
+    
+    func testThreeRightDecrease() throws {
+    let result = ChartConstructor().make_middle_row_stitch_count_change(width: 3, right_difference: -3, left_difference: 0)
+    let expected = "├─┼─┼─┼─┬─┬─┐\n"
+        XCTAssertEqual(result, expected)}
+    
+    func testTwoRightDecrease() throws {
+    let result = ChartConstructor().make_middle_row_stitch_count_change(width: 3, right_difference: -2, left_difference: 0)
+    let expected = "├─┼─┼─┼─┬─┐\n"
+        XCTAssertEqual(result, expected)}
+    
+}
+
+
+
+
 class FullChartPrinterTests: XCTestCase {
     // Full Chart Tests
     
@@ -107,15 +129,29 @@ class FullChartPrinterTests: XCTestCase {
     }
     
     func testFullPatternRightSSKDecrease() throws {
-        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "ssk"],["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],["k1", "k1", "p1", "p1", "k1", "k1"]])
+        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "k1"],["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],["k1", "k1", "p1", "p1", "k1", "ssk"]])
         let expectedresult = """
 ┌─┬─┬─┬─┬─┬─┐
-│ │ │-│-│ │ │
-├─┼─┼─┼─┼─┼─┤─┐
+│ │ │-│-│ │\\│
+├─┼─┼─┼─┼─┼─┼─┐
 │ │ │-│-│ │ │\\│
-├─┼─┼─┼─┼─┼─┼─┤─┐
-│ │ │-│-│ │ │-│\\│
+├─┼─┼─┼─┼─┼─┼─┼─┐
+│ │ │-│-│ │ │-│ │
 └─┴─┴─┴─┴─┴─┴─┴─┘
+"""
+        XCTAssertEqual(result, expectedresult)
+    }
+    
+    
+    
+    func testFullPatternTripleRightSSKDecrease() throws {
+        let result = ChartConstructor().make_chart(stitch_array: [["k1", "k1", "p1", "p1", "k1", "k1","k1", "k1","k1", "k1"],["k1", "k1", "p1", "p1", "ssk", "ssk", "ssk"]])
+        let expectedresult = """
+┌─┬─┬─┬─┬─┬─┬─┐
+│ │ │-│-│\\│\\│\\│
+├─┼─┼─┼─┼─┼─┼─┼─┬─┬─┐
+│ │ │-│-│ │ │ │ │ │ │
+└─┴─┴─┴─┴─┴─┴─┴─┴─┴─┘
 """
         XCTAssertEqual(result, expectedresult)
     }

--- a/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartConstructorTest.swift
@@ -1,23 +1,20 @@
 import Foundation
 import XCTest
+import Nimble
 @testable import SwiftCliCore
 
 class TopLevelPrinterTests: XCTestCase {
 
-    // Top Level Tests
     func testPrintTopLevelMany() throws {
-        let result = ChartConstructor().makeTopRow(width: 4)
-        XCTAssertEqual(result, "┌─┬─┬─┬─┐\n")
+        expect(ChartConstructor().makeTopRow(width: 4))=="┌─┬─┬─┬─┐\n"
     }
 
     func testPrintTopLevelOne() throws {
-        let result = ChartConstructor().makeTopRow(width: 1)
-        XCTAssertEqual(result, "┌─┐\n")
+        expect(ChartConstructor().makeTopRow(width: 1))=="┌─┐\n"
     }
 
     func testPrintTopLevelZero() throws {
-        let result = ChartConstructor().makeTopRow(width: 0)
-        XCTAssertEqual(result, "\n")
+        expect(ChartConstructor().makeTopRow(width: 0))=="\n"
     }
 
 }
@@ -25,79 +22,62 @@ class BottomLevelPrinterTests: XCTestCase {
 
     // Bottom Level Tests
     func testPrintBottomLevelMany() throws {
-        let result = ChartConstructor().makeBottomRow(width: 4)
-        XCTAssertEqual(result, "└─┴─┴─┴─┘")
+        expect(ChartConstructor().makeBottomRow(width: 4))=="└─┴─┴─┴─┘"
     }
 
     func testPrintBottomLevelOne() throws {
-        let result = ChartConstructor().makeBottomRow(width: 1)
-        XCTAssertEqual(result, "└─┘")
+        expect(ChartConstructor().makeBottomRow(width: 1))=="└─┘"
     }
 
     func testPrintBottomLevelZero() throws {
-        let result = ChartConstructor().makeBottomRow(width: 0)
-        XCTAssertEqual(result, "")
+        expect(ChartConstructor().makeBottomRow(width: 0))==""
     }
 }
 class MiddleLevelPrinterTests: XCTestCase {
 
-    // Middle-of-Rows Tests
-
     func testPrintMiddleLevelMany() throws {
-        let result = ChartConstructor().makeMiddleRow(width: 4)
-        XCTAssertEqual(result, "├─┼─┼─┼─┤\n")
+        expect(ChartConstructor().makeMiddleRow(width: 4))=="├─┼─┼─┼─┤\n"
     }
 
     func testPrintMiddleLevelOne() throws {
-        let result = ChartConstructor().makeMiddleRow(width: 1)
-        XCTAssertEqual(result, "├─┤\n")
+        expect(ChartConstructor().makeMiddleRow(width: 1))=="├─┤\n"
     }
 
     func testPrintMiddleLevelZero() throws {
-        let result = ChartConstructor().makeMiddleRow(width: 0)
-        XCTAssertEqual(result, "\n")
+        expect(ChartConstructor().makeMiddleRow(width: 0))=="\n"
     }
 
 }
 class StitchRowPrinterTests: XCTestCase {
-    // Stitch Row Tests
 
     func testPrintStitchRowMany() throws {
-        let result = ChartConstructor().makeStitchRow(row: ["k1", "k1", "p1", "p1", "k1", "k1"])
-        XCTAssertEqual(result, "│ │ │-│-│ │ │\n")
+        expect(ChartConstructor().makeStitchRow(row: ["k1", "k1", "p1", "p1", "k1", "k1"]))=="│ │ │-│-│ │ │\n"
     }
 
     func testPrintStitchRowOne() throws {
-        let result = ChartConstructor().makeStitchRow(row: ["k1"])
-        XCTAssertEqual(result, "│ │\n")
+        expect(ChartConstructor().makeStitchRow(row: ["k1"]))=="│ │\n"
     }
 
     func testPrintStitchRowZero() throws {
-        let result = ChartConstructor().makeStitchRow(row: [""])
-        XCTAssertEqual(result, "\n")
+        expect(ChartConstructor().makeStitchRow(row: [""]))=="\n"
     }
 
 }
 
 class RightDecreaseMiddlePrinterTests: XCTestCase {
     func testOneRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 6, rDiff: -1, lDiff: 0)
-        let expected = "├─┼─┼─┼─┼─┼─┼─┐\n"
-        XCTAssertEqual(result, expected)
+        expect(ChartConstructor().makeMiddleRowStitchCountChange(width: 6, rDiff: -1, lDiff: 0))=="├─┼─┼─┼─┼─┼─┼─┐\n"
 
     }
 
     func testThreeRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -3, lDiff: 0)
-        let expected = "├─┼─┼─┼─┬─┬─┐\n"
-        XCTAssertEqual(result, expected)
+        expect(ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -3, lDiff: 0))=="├─┼─┼─┼─┬─┬─┐\n"
+
 
     }
 
     func testTwoRightDecrease() throws {
-        let result = ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -2, lDiff: 0)
-        let expected = "├─┼─┼─┼─┬─┐\n"
-        XCTAssertEqual(result, expected)
+        expect(ChartConstructor().makeMiddleRowStitchCountChange(width: 3, rDiff: -2, lDiff: 0))=="├─┼─┼─┼─┬─┐\n"
 
     }
 
@@ -107,32 +87,29 @@ class FullChartPrinterTests: XCTestCase {
     // Full Chart Tests
 
     func testFullPatternOneRow() throws {
-        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"]])
-        let expectedresult = """
+        expect(ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"]]))=="""
 ┌─┬─┬─┬─┬─┬─┐
 │ │ │-│-│ │ │
 └─┴─┴─┴─┴─┴─┘
 """
-        XCTAssertEqual(result, expectedresult)
+
     }
     func testFullPatternTwoRow() throws {
-        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"],
-                                                                ["p1", "p1", "k1", "k1", "p1", "p1"]])
-        let expectedresult = """
+        expect(ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1"],
+                                                          ["p1", "p1", "k1", "k1", "p1", "p1"]]))=="""
 ┌─┬─┬─┬─┬─┬─┐
 │-│-│ │ │-│-│
 ├─┼─┼─┼─┼─┼─┤
 │ │ │-│-│ │ │
 └─┴─┴─┴─┴─┴─┘
 """
-        XCTAssertEqual(result, expectedresult)
+
     }
 
     func testFullPatternRightSSKDecrease() throws {
-        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "k1"],
-                                                                ["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],
-                                                                ["k1", "k1", "p1", "p1", "k1", "ssk"]])
-        let expectedresult = """
+        expect(ChartConstructor().makeChart(stitchArray: [["k1", "k1", "p1", "p1", "k1", "k1", "p1", "k1"],
+                                                          ["k1", "k1", "p1", "p1", "k1", "k1", "ssk"],
+                                                          ["k1", "k1", "p1", "p1", "k1", "ssk"]]))=="""
 ┌─┬─┬─┬─┬─┬─┐
 │ │ │-│-│ │\\│
 ├─┼─┼─┼─┼─┼─┼─┐
@@ -141,20 +118,18 @@ class FullChartPrinterTests: XCTestCase {
 │ │ │-│-│ │ │-│ │
 └─┴─┴─┴─┴─┴─┴─┴─┘
 """
-        XCTAssertEqual(result, expectedresult)
     }
 
     func testFullPatternTripleRightSSKDecrease() throws {
-        let result = ChartConstructor().makeChart(stitchArray: [["k1", "k1", "k1", "k1", "k1", "k1", "k1", "k1"],
-                                                                ["k1", "k1", "ssk", "ssk", "ssk"]])
-        let expectedresult = """
+        expect(ChartConstructor().makeChart(stitchArray: [["k1", "k1", "k1", "k1", "k1", "k1", "k1", "k1"],
+                                                                ["k1", "k1", "ssk", "ssk", "ssk"]])) == """
 ┌─┬─┬─┬─┬─┐
 │ │ │\\│\\│\\│
 ├─┼─┼─┼─┼─┼─┬─┬─┐
 │ │ │ │ │ │ │ │ │
 └─┴─┴─┴─┴─┴─┴─┴─┘
 """
-        XCTAssertEqual(result, expectedresult)
+
     }
 
 }

--- a/Tests/SwiftCliCoreTests/ChartifyTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartifyTest.swift
@@ -2,8 +2,7 @@ import Foundation
 import XCTest
 @testable import SwiftCliCore
 
-
 class ChartifyFinishedTest: XCTestCase {
     // to do
-    
+
 }

--- a/Tests/SwiftCliCoreTests/ChartifyTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartifyTest.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import Nimble
 @testable import SwiftCliCore
 
 class ChartifyFinishedTest: XCTestCase {

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -5,30 +5,43 @@ import Nimble
 
 class ValidatorTests: XCTestCase {
     // Valid Input
-
     func testValidatorForP1Input() throws {
-        expect(InputValidator().validate(pattern: "p1"))==true
+        let result = InputValidator().validate(pattern: "p1")
+        let expectedResult = true
+        expect(result).to(equal(expectedResult))
+
     }
     func testValidatorForK1P1Input() throws {
-        expect(InputValidator().validate(pattern: "k1 p1"))==true
+        let result = InputValidator().validate(pattern: "k1 p1")
+        let expectedResult = true
+        expect(result).to(equal(expectedResult))
 
     }
 
     func testValidatorForLineBreaks() throws {
-        expect(InputValidator().validate(pattern: "k1 p1 \n"))==true
+        let result = InputValidator().validate(pattern: "k1 p1 \n")
+        let expectedResult = true
+        expect(result).to(equal(expectedResult))
+
     }
 
     // Invalid Input
     func testValidatorForG1P1Input() throws {
-        expect(InputValidator().validate(pattern: "g1 p1"))==false
+        let result = InputValidator().validate(pattern: "g1 p1")
+        let expectedResult = false
+        expect(result).to(equal(expectedResult))
     }
 
     func testValidatorFor0Input() throws {
-        expect(InputValidator().validate(pattern: ""))==false
+        let result = InputValidator().validate(pattern: "")
+        let expectedResult = false
+        expect(result).to(equal(expectedResult))
     }
 
     func testValidatorForMiscBadInput() throws {
-        expect(InputValidator().validate(pattern: "3"))==false
+        let result = InputValidator().validate(pattern: "3")
+        let expectedResult = false
+        expect(result).to(equal(expectedResult))
     }
 
 }
@@ -36,25 +49,38 @@ class ValidatorTests: XCTestCase {
 class ArrayMakerTests: XCTestCase {
 
     func testValidatorForTwoRowInput() throws {
-        expect(InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1"))==[["k1", "p1"], ["k1", "p1"]]
+        let result = InputValidator().arrayMaker(cleanedPattern: "k1 p1 \n k1 p1")
+        let expectedResult = [["k1", "p1"], ["k1", "p1"]]
+        expect(result).to(equal(expectedResult))
     }
 
     func testValidatorForManyRowInputs() throws {
-        expect(InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n"))==[["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"]]
+        let result = InputValidator().arrayMaker(cleanedPattern:  "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
+        let expectedResult = [["k1", "p1"],
+                              ["k1", "p1"],
+                              ["k1", "p1"],
+                              ["k1", "p1"]]
+        expect(result).to(equal(expectedResult))
 
     }
 
     func testValidatorForExtraLinebreak() throws {
-        expect(InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n")) == [["k1", "p1"]]
+        let result = InputValidator().arrayMaker(cleanedPattern:  "k1 p1 \n")
+        let expectedResult = [["k1", "p1"]]
+        expect(result).to(equal(expectedResult))
     }
 
     func testValidatorForThreeExtraLinebreak() throws {
-        expect(InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n \n \n"))==[["k1", "p1"]]
+        let result = InputValidator().arrayMaker(cleanedPattern:  "k1 p1 \n \n \n")
+        let expectedResult = [["k1", "p1"]]
+        expect(result).to(equal(expectedResult))
 
     }
 
     func testValidatorForOneStitch() throws {
-        expect(InputValidator().arrayMaker(cleanedpattern: "k1"))==[["k1"]]
+        let result = InputValidator().arrayMaker(cleanedPattern:  "k1")
+        let expectedResult = [["k1"]]
+        expect(result).to(equal(expectedResult))
     }
 
 }

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -96,4 +96,4 @@ class findWidestTests: XCTestCase {
 //        let IsItTheSame = arrayCompare(array1: result, array2: expected)
 //        XCTAssertEqual(IsItTheSame, true)
 //    }
-}
+

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class ValidatorTests: XCTestCase {
     // Valid Input
-
+    
     func testValidatorForP1Input() throws {
         let result = InputValidator().validate(pattern: "p1")
         XCTAssertEqual(result, true)
@@ -37,7 +37,7 @@ class ValidatorTests: XCTestCase {
         XCTAssertEqual(result, false)
     }
     
-
+    
 }
 
 class ArrayMakerTests: XCTestCase {
@@ -45,55 +45,33 @@ class ArrayMakerTests: XCTestCase {
     
     
     func testValidatorForTwoRowInput() throws {
-        let result : [[String]] = InputValidator().ArrayMaker(cleanedpattern: "k1 p1 \n k1 p1")
+        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1")
         let expected : [[String]] = [["k1", "p1"], ["k1", "p1"]]
         XCTAssertEqual(result, expected)
     }
     
     func testValidatorForManyRowInputs() throws {
-        let result : [[String]] = InputValidator().ArrayMaker(cleanedpattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
+        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
         let expected : [[String]] = [["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"]]
         XCTAssertEqual(result, expected)
     }
     
     func testValidatorForExtraLinebreak() throws {
-        let result : [[String]] = InputValidator().ArrayMaker(cleanedpattern: "k1 p1 \n")
+        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n")
         let expected : [[String]] = [["k1", "p1"]]
         XCTAssertEqual(result, expected)
     }
     
     func testValidatorForThreeExtraLinebreak() throws {
-        let result : [[String]] = InputValidator().ArrayMaker(cleanedpattern: "k1 p1 \n \n \n")
+        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n \n \n")
         let expected : [[String]] = [["k1", "p1"]]
         XCTAssertEqual(result, expected)
     }
     
     func testValidatorForOneStitch() throws {
-        let result : [[String]] = InputValidator().ArrayMaker(cleanedpattern: "k1")
+        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1")
         let expected : [[String]] = [["k1"]]
         XCTAssertEqual(result, expected)
     }
     
 }
-
-class findWidestTests: XCTestCase {
-    func testValidatorForWidestRowMultiple() throws {
-        let result = InputValidator().FindWidestRow(patternarray: [["k1", "p1"], ["k1", "p1", "k1"],["p1"]])
-        XCTAssertEqual(result, 1)
-    }
-    
-    func testValidatorForWidestRowSingle() throws {
-        let result = InputValidator().FindWidestRow(patternarray: [["p1"]])
-        XCTAssertEqual(result, 0)
-    }
-}
-
-
-//class CenteredArrayMaker: XCTestCase {
-//    func testCenteredArrayMakerDecrease() throws{
-//        let result = InputValidator().CenteredArrayMaker(array: [["k1", "ssk"],["k1"]])
-//        let expected = [["k1", "ssk"],["k1", "NOSTITCH"]]
-//        let IsItTheSame = arrayCompare(array1: result, array2: expected)
-//        XCTAssertEqual(IsItTheSame, true)
-//    }
-

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -55,7 +55,7 @@ class ArrayMakerTests: XCTestCase {
     }
 
     func testValidatorForManyRowInputs() throws {
-        let result = InputValidator().arrayMaker(cleanedPattern:  "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
+        let result = InputValidator().arrayMaker(cleanedPattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
         let expectedResult = [["k1", "p1"],
                               ["k1", "p1"],
                               ["k1", "p1"],
@@ -65,20 +65,20 @@ class ArrayMakerTests: XCTestCase {
     }
 
     func testValidatorForExtraLinebreak() throws {
-        let result = InputValidator().arrayMaker(cleanedPattern:  "k1 p1 \n")
+        let result = InputValidator().arrayMaker(cleanedPattern: "k1 p1 \n")
         let expectedResult = [["k1", "p1"]]
         expect(result).to(equal(expectedResult))
     }
 
     func testValidatorForThreeExtraLinebreak() throws {
-        let result = InputValidator().arrayMaker(cleanedPattern:  "k1 p1 \n \n \n")
+        let result = InputValidator().arrayMaker(cleanedPattern: "k1 p1 \n \n \n")
         let expectedResult = [["k1", "p1"]]
         expect(result).to(equal(expectedResult))
 
     }
 
     func testValidatorForOneStitch() throws {
-        let result = InputValidator().arrayMaker(cleanedPattern:  "k1")
+        let result = InputValidator().arrayMaker(cleanedPattern: "k1")
         let expectedResult = [["k1"]]
         expect(result).to(equal(expectedResult))
     }

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -49,12 +49,12 @@ class ArrayMakerTests: XCTestCase {
     }
 
     func testValidatorForThreeExtraLinebreak() throws {
-        expect(InputValidator().arrayMaker(cleanedpattern:"k1 p1 \n \n \n"))==[["k1", "p1"]]
+        expect(InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n \n \n"))==[["k1", "p1"]]
 
     }
 
     func testValidatorForOneStitch() throws {
-        expect(InputValidator().arrayMaker(cleanedpattern:"k1"))==[["k1"]]
+        expect(InputValidator().arrayMaker(cleanedpattern: "k1"))==[["k1"]]
     }
 
 }

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -86,12 +86,12 @@ class ArrayMakerTests: XCTestCase {
 
 class findWidestTests: XCTestCase {
     func testValidatorForWidestRowMultiple() throws {
-        let result = Validator().FindWidestRow(patternarray: [["k1", "p1"], ["k1", "p1", "k1"],["p1"]])
+        let result = InputValidator().FindWidestRow(patternarray: [["k1", "p1"], ["k1", "p1", "k1"],["p1"]])
         XCTAssertEqual(result, 1)
     }
     
     func testValidatorForWidestRowSingle() throws {
-        let result = Validator().FindWidestRow(patternarray: [["p1"]])
+        let result = InputValidator().FindWidestRow(patternarray: [["p1"]])
         XCTAssertEqual(result, 0)
     }
 }
@@ -99,7 +99,7 @@ class findWidestTests: XCTestCase {
 
 class CenteredArrayMaker: XCTestCase {
     func testCenteredArrayMakerDecrease() throws{
-        let result = Validator().CenteredArrayMaker(array: [["k1", "ssk"],["k1"]])
+        let result = InputValidator().CenteredArrayMaker(array: [["k1", "ssk"],["k1"]])
         let expected = [["k1", "ssk"],["k1", "NOSTITCH"]]
         print(result)
         print(expected)

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -47,20 +47,12 @@ class ArrayMakerTests: XCTestCase {
     func testValidatorForTwoRowInput() throws {
         let result : [[String]] = InputValidator().ArrayMaker(cleanedpattern: "k1 p1 \n k1 p1")
         let expected : [[String]] = [["k1", "p1"], ["k1", "p1"]]
-        print("Result:")
-        print(result)
-        print("Expected:")
-        print(expected)
         XCTAssertEqual(result, expected)
     }
     
     func testValidatorForManyRowInputs() throws {
         let result : [[String]] = InputValidator().ArrayMaker(cleanedpattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
         let expected : [[String]] = [["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"]]
-        print("Result:")
-        print(result)
-        print("Expected:")
-        print(expected)
         XCTAssertEqual(result, expected)
     }
     
@@ -97,13 +89,11 @@ class findWidestTests: XCTestCase {
 }
 
 
-class CenteredArrayMaker: XCTestCase {
-    func testCenteredArrayMakerDecrease() throws{
-        let result = InputValidator().CenteredArrayMaker(array: [["k1", "ssk"],["k1"]])
-        let expected = [["k1", "ssk"],["k1", "NOSTITCH"]]
-        print(result)
-        print(expected)
-        let IsItTheSame = arrayCompare(array1: result, array2: expected)
-        XCTAssertEqual(IsItTheSame, true)
-    }
+//class CenteredArrayMaker: XCTestCase {
+//    func testCenteredArrayMakerDecrease() throws{
+//        let result = InputValidator().CenteredArrayMaker(array: [["k1", "ssk"],["k1"]])
+//        let expected = [["k1", "ssk"],["k1", "NOSTITCH"]]
+//        let IsItTheSame = arrayCompare(array1: result, array2: expected)
+//        XCTAssertEqual(IsItTheSame, true)
+//    }
 }

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -1,11 +1,10 @@
-
 import Foundation
 import XCTest
 @testable import SwiftCliCore
 
 class ValidatorTests: XCTestCase {
     // Valid Input
-    
+
     func testValidatorForP1Input() throws {
         let result = InputValidator().validate(pattern: "p1")
         XCTAssertEqual(result, true)
@@ -14,64 +13,60 @@ class ValidatorTests: XCTestCase {
         let result = InputValidator().validate(pattern: "k1 p1")
         XCTAssertEqual(result, true)
     }
-    
+
     func testValidatorForLineBreaks() throws {
         let result = InputValidator().validate(pattern: "k1 p1 \n")
         XCTAssertEqual(result, true)
     }
-    
-    
+
     // Invalid Input
     func testValidatorForG1P1Input() throws {
         let result = InputValidator().validate(pattern: "g1 p1")
         XCTAssertEqual(result, false)
     }
-    
+
     func testValidatorFor0Input() throws {
         let result = InputValidator().validate(pattern: "")
         XCTAssertEqual(result, false)
     }
-    
+
     func testValidatorForMiscBadInput() throws {
         let result = InputValidator().validate(pattern: "3")
         XCTAssertEqual(result, false)
     }
-    
-    
+
 }
 
 class ArrayMakerTests: XCTestCase {
-    
-    
-    
+
     func testValidatorForTwoRowInput() throws {
-        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1")
-        let expected : [[String]] = [["k1", "p1"], ["k1", "p1"]]
+        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1")
+        let expected: [[String]] = [["k1", "p1"], ["k1", "p1"]]
         XCTAssertEqual(result, expected)
     }
-    
+
     func testValidatorForManyRowInputs() throws {
-        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
-        let expected : [[String]] = [["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"]]
+        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
+        let expected: [[String]] = [["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"]]
         XCTAssertEqual(result, expected)
     }
-    
+
     func testValidatorForExtraLinebreak() throws {
-        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n")
-        let expected : [[String]] = [["k1", "p1"]]
+        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n")
+        let expected: [[String]] = [["k1", "p1"]]
         XCTAssertEqual(result, expected)
     }
-    
+
     func testValidatorForThreeExtraLinebreak() throws {
-        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n \n \n")
-        let expected : [[String]] = [["k1", "p1"]]
+        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n \n \n")
+        let expected: [[String]] = [["k1", "p1"]]
         XCTAssertEqual(result, expected)
     }
-    
+
     func testValidatorForOneStitch() throws {
-        let result : [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1")
-        let expected : [[String]] = [["k1"]]
+        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1")
+        let expected: [[String]] = [["k1"]]
         XCTAssertEqual(result, expected)
     }
-    
+
 }

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -1,38 +1,34 @@
 import Foundation
 import XCTest
+import Nimble
 @testable import SwiftCliCore
 
 class ValidatorTests: XCTestCase {
     // Valid Input
 
     func testValidatorForP1Input() throws {
-        let result = InputValidator().validate(pattern: "p1")
-        XCTAssertEqual(result, true)
+        expect(InputValidator().validate(pattern: "p1"))==true
     }
     func testValidatorForK1P1Input() throws {
-        let result = InputValidator().validate(pattern: "k1 p1")
-        XCTAssertEqual(result, true)
+        expect(InputValidator().validate(pattern: "k1 p1"))==true
+
     }
 
     func testValidatorForLineBreaks() throws {
-        let result = InputValidator().validate(pattern: "k1 p1 \n")
-        XCTAssertEqual(result, true)
+        expect(InputValidator().validate(pattern: "k1 p1 \n"))==true
     }
 
     // Invalid Input
     func testValidatorForG1P1Input() throws {
-        let result = InputValidator().validate(pattern: "g1 p1")
-        XCTAssertEqual(result, false)
+        expect(InputValidator().validate(pattern: "g1 p1"))==false
     }
 
     func testValidatorFor0Input() throws {
-        let result = InputValidator().validate(pattern: "")
-        XCTAssertEqual(result, false)
+        expect(InputValidator().validate(pattern: ""))==false
     }
 
     func testValidatorForMiscBadInput() throws {
-        let result = InputValidator().validate(pattern: "3")
-        XCTAssertEqual(result, false)
+        expect(InputValidator().validate(pattern: "3"))==false
     }
 
 }
@@ -40,33 +36,25 @@ class ValidatorTests: XCTestCase {
 class ArrayMakerTests: XCTestCase {
 
     func testValidatorForTwoRowInput() throws {
-        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1")
-        let expected: [[String]] = [["k1", "p1"], ["k1", "p1"]]
-        XCTAssertEqual(result, expected)
+        expect(InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1"))==[["k1", "p1"], ["k1", "p1"]]
     }
 
     func testValidatorForManyRowInputs() throws {
-        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n")
-        let expected: [[String]] = [["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"]]
-        XCTAssertEqual(result, expected)
+        expect(InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n k1 p1 \n k1 p1 \n k1 p1 \n"))==[["k1", "p1"], ["k1", "p1"], ["k1", "p1"], ["k1", "p1"]]
+
     }
 
     func testValidatorForExtraLinebreak() throws {
-        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n")
-        let expected: [[String]] = [["k1", "p1"]]
-        XCTAssertEqual(result, expected)
+        expect(InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n")) == [["k1", "p1"]]
     }
 
     func testValidatorForThreeExtraLinebreak() throws {
-        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1 p1 \n \n \n")
-        let expected: [[String]] = [["k1", "p1"]]
-        XCTAssertEqual(result, expected)
+        expect(InputValidator().arrayMaker(cleanedpattern:"k1 p1 \n \n \n"))==[["k1", "p1"]]
+
     }
 
     func testValidatorForOneStitch() throws {
-        let result: [[String]] = InputValidator().arrayMaker(cleanedpattern: "k1")
-        let expected: [[String]] = [["k1"]]
-        XCTAssertEqual(result, expected)
+        expect(InputValidator().arrayMaker(cleanedpattern:"k1"))==[["k1"]]
     }
 
 }

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -83,3 +83,27 @@ class ArrayMakerTests: XCTestCase {
     }
     
 }
+
+class findWidestTests: XCTestCase {
+    func testValidatorForWidestRowMultiple() throws {
+        let result = Validator().FindWidestRow(patternarray: [["k1", "p1"], ["k1", "p1", "k1"],["p1"]])
+        XCTAssertEqual(result, 1)
+    }
+    
+    func testValidatorForWidestRowSingle() throws {
+        let result = Validator().FindWidestRow(patternarray: [["p1"]])
+        XCTAssertEqual(result, 0)
+    }
+}
+
+
+class CenteredArrayMaker: XCTestCase {
+    func testCenteredArrayMakerDecrease() throws{
+        let result = Validator().CenteredArrayMaker(array: [["k1", "ssk"],["k1"]])
+        let expected = [["k1", "ssk"],["k1", "NOSTITCH"]]
+        print(result)
+        print(expected)
+        let IsItTheSame = arrayCompare(array1: result, array2: expected)
+        XCTAssertEqual(IsItTheSame, true)
+    }
+}

--- a/Tests/SwiftCliTests/SwiftCliTests.swift
+++ b/Tests/SwiftCliTests/SwiftCliTests.swift
@@ -27,7 +27,7 @@ final class SwiftCliTests: XCTestCase {
         process.waitUntilExit()
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: data, encoding: .utf8)
+        var output = String(data: data, encoding: .utf8)
 
         //    XCTAssertEqual(output, "Hello, world!\n")
         #endif


### PR DESCRIPTION
## What?
I've added support for functions where the stitch count on the right decreases relative to the previous row. 
## Why?
So that users can have stitch decreases accurately visualized.
## How?
Added new method `make_middle_row_stitch_count_change` to Class `ChartConstructor`. I added new logic to existing function `ChartConstructor().make_chart` that checks if the current row is smaller than the previous row, and if so, calls `make_middle_row_stitch_count_change` instead of `make_middle_row` to "draw" the grid row between the previous and current row. 


## Testing?

Tests have been added for the method `make_middle_row_stitch_count_change` in the file ChartConstructorTest under 'RightDecreaseMiddlePrinterTests'.  Several full-chart test cases have also been added under existing class `FullChartPrinterTests` which tests the output of `make_chart`.

## Anything Else?

`make_middle_row_stitch_count_change` is set up to take in values for either an increase or decrease on both the left and right sides of the row, which can be implemented later. For now, we only handle right side decreases.
