### PR TITLE
Add error for invalid stitch's Row

### DIFF
--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -2,8 +2,7 @@ import Foundation
 
 enum InputError: Error, Equatable {
     case emptyRow
-    case invalidStitch(invalidStitch: String)
-    case invalidStitchWithLocation(invalidStitch: String, rowLocation: Int)
+    case invalidStitch(invalidStitch: String, rowLocation: Int? = nil)
     case invalidRowWidth(invalidRowNumber: Int, expectedStitchCount: Int, actualCount: Int)
 }
 
@@ -12,9 +11,7 @@ extension InputError: LocalizedError {
         switch self {
         case .emptyRow:
             return emptyRowError()
-        case .invalidStitch(let invalidUserStitch):
-            return invalidStitchError(invalidUserStitch: invalidUserStitch)
-        case .invalidStitchWithLocation(let invalidStitch, let rowLocation):
+        case .invalidStitch(let invalidStitch, let rowLocation):
             return invalidStitchWithLocationError(
                 invalidStitch: invalidStitch,
                 rowLocation: rowLocation
@@ -46,12 +43,7 @@ func emptyRowError() -> String {
     """
 }
 
-func invalidStitchError(invalidUserStitch: String) -> String {
-    return """
-    Invalid Stitch Error:
-    \(invalidUserStitch) is not a valid stitch.
-    """
-}
+
 
 func invalidRowWidthError(invalidRowNumber: Int, expectedStitchCount: Int, actualCount: Int) -> String {
     let row = String(invalidRowNumber)
@@ -65,9 +57,17 @@ func invalidRowWidthError(invalidRowNumber: Int, expectedStitchCount: Int, actua
     )
 }
 
-func invalidStitchWithLocationError(invalidStitch: String, rowLocation: Int) -> String {
-    return """
+func invalidStitchWithLocationError(invalidStitch: String, rowLocation: Int?) -> String {
+    if let location = rowLocation {
+        return """
     Invalid Stitch Error:
-    \(invalidStitch) on Row \(rowLocation) is not a valid stitch.
+    \(invalidStitch) on Row \(location) is not a valid stitch.
     """
+    } else {
+        return """
+    Invalid Stitch Error:
+    \(invalidStitch) is not a valid stitch.
+    """
+    }
+
 }

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -15,7 +15,7 @@ public class InputValidator {
             }
         }
 
-        var patternNestedArray =  pattern.map { arrayMaker(row: $0) }
+        var patternNestedArray =  pattern.map { NestedArrayBuilder().arrayMaker(row: $0) }
         if (knitFlat == true) {
             patternNestedArray = knitFlatArray(array: patternNestedArray)
         }
@@ -41,16 +41,11 @@ public class InputValidator {
         }
     }
 
-    private func arrayMaker(row: String) -> [String] {
-        let substringRowStitches = row.split(separator: " ")
-        let rowStitches = substringRowStitches.map {(String($0))}
-        return(rowStitches)
-    }
 
     private func validateEachStitch(stitchRow: [String], index: Int) -> Result<[String], InputError> {
         for stitch in stitchRow {
             guard isStitchValid(stitch: String(stitch)) == true else {
-                return .failure(InputError.invalidStitchWithLocation(invalidStitch: String(stitch), rowLocation: index + 1))
+                return .failure(InputError.invalidStitch(invalidStitch: String(stitch), rowLocation: index + 1))
             }
         }
         return .success(stitchRow)

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public class NestedArrayBuilder {
+    public init() {}
+
+    public func arrayMaker(row: String) -> [String] {
+        let substringRowStitches = row.split(separator: " ")
+        let rowStitches = substringRowStitches.map {(String($0))}
+        return(rowStitches)
+    }
+}

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -6,7 +6,7 @@ import Nimble
 class ValidatorTests: XCTestCase {
     func testInvalidStitchShouldThrowError() throws {
         let testPattern = ["g1 p1"]
-        let err = InputError.invalidStitchWithLocation(invalidStitch: "g1", rowLocation: 1)
+        let err = InputError.invalidStitch(invalidStitch: "g1", rowLocation: 1)
         expect { try InputValidator().inputValidation(pattern: testPattern, knitFlat: false) }.to(throwError(err))
     }
 

--- a/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
+++ b/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
@@ -1,0 +1,18 @@
+import Foundation
+import XCTest
+import Nimble
+@testable import SwiftCliCore
+
+class NestedArrayMakerTest: XCTestCase {
+
+    func testNestedArrayBuilderEmpty() throws {
+        let result = NestedArrayBuilder().arrayMaker(row: "")
+        expect(result).to(equal([]))
+    }
+
+    func testNestedArrayBuilder() throws {
+        let result = NestedArrayBuilder().arrayMaker(row: "k1 k1 k1")
+        expect(result).to(equal(["k1", "k1", "k1"]))
+    }
+
+}


### PR DESCRIPTION
Created a new error in the `InputError` enum that gives row context - `invalidStitchWithLocation(invalidStitch: String, rowLocation: Int)` -  rather than modify the`invalidStitch` error (which is used on its own as the result of a stitch lookup function without the context of a row). Now in InputValidator, we go through an `.enumerated()` version of the `patternNestedArray` so we have the index of each sub-array (row) we are checking, and can pass that to the user in the `invalidStitchWithLocation` error (adjusted with a + 1 so that it's the row number as the user would see it). 