### PR TITLE
Multiple error array

### DIFF
--- a/Sources/SwiftCli/main.swift
+++ b/Sources/SwiftCli/main.swift
@@ -15,8 +15,6 @@ struct StartProgram: ParsableCommand {
     @Option(help: "File name to save pattern under.")
     var outputFile: String?
 
-
-
     func run() {
         let patternNormalizer = PatternNormalizer()
         let nestedArrayBuilder = NestedArrayBuilder()
@@ -24,19 +22,18 @@ struct StartProgram: ParsableCommand {
         let chartConstructor = ChartConstructor()
         let fileValidator = FileValidator()
         let fileWriter = FileWriter()
-      
+
         let chartify = Chartify(
-          inputValidator: inputValidator, 
-          chartConstructor: chartConstructor, 
-          fileValidator: fileValidator, 
+          inputValidator: inputValidator,
+          chartConstructor: chartConstructor,
+          fileValidator: fileValidator,
           fileWriter: fileWriter
         )
         chartify.run(
-          userInput: pattern, 
-          file: file, 
-          knitFlat: knitFlat, 
+          userInput: pattern,
+          file: file,
+          knitFlat: knitFlat,
           fileNameToWrite: outputFile)
-
 
     }
 }

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -8,11 +8,15 @@ public final class Chartify {
     var fileValidator: FileValidator
     var fileWriter: FileWriter
 
-    public init(inputValidator: InputValidator, chartConstructor: ChartConstructor, fileValidator: FileValidator, fileWriter: FileWriter) {
-        self.inputValidator = inputValidator
-        self.chartConstructor = chartConstructor
-        self.fileValidator = fileValidator
-        self.fileWriter = fileWriter
+    public init(
+        inputValidator: InputValidator,
+        chartConstructor: ChartConstructor,
+        fileValidator: FileValidator,
+        fileWriter: FileWriter) {
+            self.inputValidator = inputValidator
+            self.chartConstructor = chartConstructor
+            self.fileValidator = fileValidator
+            self.fileWriter = fileWriter
     }
 
     public func run(userInput: [String], file: String? = nil, knitFlat: Bool = false, fileNameToWrite: String? = nil) {
@@ -57,5 +61,3 @@ public final class Chartify {
     }
 
 }
-
-

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -85,15 +85,15 @@ func invalidStitchWithLocationError(invalidStitch: String, rowLocation: Int?, st
     var onRow = ""
     var atIndex = ""
     if let rowLocation = rowLocation {
-        onRow = "on row \(rowLocation)"
+        onRow = " on row \(rowLocation)"
     }
     if let stitchIndexInRow = stitchIndexInRow {
-        atIndex = "at index \(stitchIndexInRow)"
+        atIndex = " at index \(stitchIndexInRow)"
     }
 
     return """
     Invalid Stitch Error:
-    '\(invalidStitch)' \(onRow) \(atIndex) is not a valid stitch.
+    '\(invalidStitch)'\(atIndex)\(onRow) is not a valid stitch type.
     """
 
 
@@ -103,15 +103,15 @@ func invalidStitchNumberError(rowNumber: Int?, invalidStitch: String, validStitc
     var onRow = ""
     var atIndex = ""
     if let rowNumber = rowNumber {
-        onRow = "on row \(rowNumber)"
+        onRow = " on row \(rowNumber)"
     }
     if let stitchIndexInRow = stitchIndexInRow {
-        atIndex = "at index \(stitchIndexInRow)"
+        atIndex = " at index \(stitchIndexInRow)"
     }
 
     return """
     Invalid Stitch Count Error:
-    '\(invalidStitch)' \(onRow) \(atIndex) starts with valid stitch type \(validStitchType) but ends with the invalid stitch count \(invalidStitchCount). Please enter a positive integer number of stitches.
+    '\(invalidStitch)'\(atIndex)\(onRow) starts with valid stitch type \(validStitchType) but ends with the invalid stitch count \(invalidStitchCount). Please enter a positive integer number of stitches.
     """
 
 }

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -96,7 +96,6 @@ func invalidStitchWithLocationError(invalidStitch: String, rowLocation: Int?, st
     '\(invalidStitch)'\(atIndex)\(onRow) is not a valid stitch type.
     """
 
-
 }
 
 func invalidStitchNumberError(rowNumber: Int?, invalidStitch: String, validStitchType: String, invalidStitchCount: String, stitchIndexInRow: Int?) -> String {
@@ -118,7 +117,7 @@ func invalidStitchNumberError(rowNumber: Int?, invalidStitch: String, validStitc
 
 func multipleErrorsMessage(errors: [InputError]) -> String {
     var allErrorMessages = ""
-    for error in errors{
+    for error in errors {
         allErrorMessages.append(error.localizedDescription)
         allErrorMessages.append("\n")
     }

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -4,7 +4,7 @@ enum InputError: Error, Equatable {
     case emptyRow
     case invalidStitch(invalidStitch: String, rowLocation: Int? = nil, stitchIndexInRow: Int? = nil)
     case invalidRowWidth(invalidRowNumber: Int, expectedStitchCount: Int, actualCount: Int)
-    case invalidStitchNumber(rowNumber: Int? = nil, invalidStitch: String, validStitchType: String, invalidStitchNumber: String, stitchIndexInRow: Int? = nil)
+    case invalidStitchNumber(rowNumber: Int, invalidStitch: String, validStitchType: String, invalidStitchNumber: String, stitchIndexInRow: Int)
     case multipleErrors(errors: [InputError])
 }
 

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -2,9 +2,10 @@ import Foundation
 
 enum InputError: Error, Equatable {
     case emptyRow
-    case invalidStitch(invalidStitch: String, rowLocation: Int? = nil)
+    case invalidStitch(invalidStitch: String, rowLocation: Int? = nil, stitchIndexInRow: Int? = nil)
     case invalidRowWidth(invalidRowNumber: Int, expectedStitchCount: Int, actualCount: Int)
-    case invalidStitchNumber(rowNumber: Int? = nil, invalidStitch: String, validStitchType: String, invalidStitchNumber: String)
+    case invalidStitchNumber(rowNumber: Int? = nil, invalidStitch: String, validStitchType: String, invalidStitchNumber: String, stitchIndexInRow: Int? = nil)
+    case multipleErrors(errors: [InputError])
 }
 
 extension InputError: LocalizedError {
@@ -12,10 +13,11 @@ extension InputError: LocalizedError {
         switch self {
         case .emptyRow:
             return emptyRowError()
-        case .invalidStitch(let invalidStitch, let rowLocation):
+        case .invalidStitch(let invalidStitch, let rowLocation, let stitchIndexInRow):
             return invalidStitchWithLocationError(
                 invalidStitch: invalidStitch,
-                rowLocation: rowLocation
+                rowLocation: rowLocation,
+                stitchIndexInRow: stitchIndexInRow
             )
         case .invalidRowWidth(let invalidRowNumber, let expectedStitchCount, let actualCount):
             return invalidRowWidthError(
@@ -23,13 +25,16 @@ extension InputError: LocalizedError {
                 expectedStitchCount: expectedStitchCount,
                 actualCount: actualCount
             )
-        case .invalidStitchNumber(let rowNumber, let invalidStitch, let validStitchType, let invalidStitchNumber):
+        case .invalidStitchNumber(let rowNumber, let invalidStitch, let validStitchType, let invalidStitchNumber, let stitchIndexInRow):
             return invalidStitchNumberError(
                 rowNumber: rowNumber,
                 invalidStitch: invalidStitch,
                 validStitchType: validStitchType,
-                invalidStitchCount: invalidStitchNumber
+                invalidStitchCount: invalidStitchNumber,
+                stitchIndexInRow: stitchIndexInRow
             )
+        case .multipleErrors(let errors):
+            return multipleErrorsMessage(errors: errors)
         }
     }
 }
@@ -76,34 +81,46 @@ func invalidRowWidthError(invalidRowNumber: Int, expectedStitchCount: Int, actua
     )
 }
 
-func invalidStitchWithLocationError(invalidStitch: String, rowLocation: Int?) -> String {
-    if let location = rowLocation {
-        return """
-    Invalid Stitch Error:
-    \(invalidStitch) on Row \(location) is not a valid stitch.
-    """
-    } else {
-        return """
-    Invalid Stitch Error:
-    \(invalidStitch) is not a valid stitch.
-    """
+func invalidStitchWithLocationError(invalidStitch: String, rowLocation: Int?, stitchIndexInRow: Int?) -> String {
+    var onRow = ""
+    var atIndex = ""
+    if let rowLocation = rowLocation {
+        onRow = "on row \(rowLocation)"
     }
+    if let stitchIndexInRow = stitchIndexInRow {
+        atIndex = "at index \(stitchIndexInRow)"
+    }
+
+    return """
+    Invalid Stitch Error:
+    '\(invalidStitch)' \(onRow) \(atIndex) is not a valid stitch.
+    """
+
 
 }
 
-func invalidStitchNumberError(rowNumber: Int?, invalidStitch: String, validStitchType: String, invalidStitchCount: String) -> String {
+func invalidStitchNumberError(rowNumber: Int?, invalidStitch: String, validStitchType: String, invalidStitchCount: String, stitchIndexInRow: Int?) -> String {
+    var onRow = ""
+    var atIndex = ""
     if let rowNumber = rowNumber {
-        return """
-    Invalid Stitch Count Error:
-    \(invalidStitch) on Row \(rowNumber) starts with valid stitch type \(validStitchType) but ends with the invalid stitch count \(invalidStitchCount). Please enter a positive integer number of stitches.
-    """
+        onRow = "on row \(rowNumber)"
     }
-    else {
-        return """
-    Invalid Stitch Count Error:
-    \(invalidStitch) starts with valid stitch type \(validStitchType) but ends with the invalid stitch count \(invalidStitchCount). Please enter a positive integer number of stitches.
-    """
+    if let stitchIndexInRow = stitchIndexInRow {
+        atIndex = "at index \(stitchIndexInRow)"
     }
 
+    return """
+    Invalid Stitch Count Error:
+    '\(invalidStitch)' \(onRow) \(atIndex) starts with valid stitch type \(validStitchType) but ends with the invalid stitch count \(invalidStitchCount). Please enter a positive integer number of stitches.
+    """
 
+}
+
+func multipleErrorsMessage(errors: [InputError]) -> String {
+    var allErrorMessages = ""
+    for error in errors{
+        allErrorMessages.append(error.localizedDescription)
+        allErrorMessages.append("\n")
+    }
+    return allErrorMessages
 }

--- a/Sources/SwiftCliCore/FileWriter.swift
+++ b/Sources/SwiftCliCore/FileWriter.swift
@@ -7,7 +7,6 @@ public class FileWriter {
                           filePath: String,
                           fileName: String) throws {
 
-
         do {
             try chart.write(toFile: filePath + "//" + fileName + ".txt",
                             atomically: true,

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -4,7 +4,6 @@ public class InputValidator {
     var patternNormalizer = PatternNormalizer()
     var nestedArrayBuilder = NestedArrayBuilder()
 
-
     public init(patternNormalizer: PatternNormalizer, nestedArrayBuilder: NestedArrayBuilder) {
 
         self.patternNormalizer = patternNormalizer
@@ -18,7 +17,7 @@ public class InputValidator {
         try checkNoEmptyRowsInArrayOfStrings(pattern: lowercaseNormalizedPattern)
 
         var patternNestedArray =  lowercaseNormalizedPattern.map { nestedArrayBuilder.arrayMaker(row: $0) }
-        if (knitFlat == true) {
+        if knitFlat == true {
             patternNestedArray = knitFlatArray(array: patternNestedArray)
         }
 
@@ -45,7 +44,6 @@ public class InputValidator {
         return pattern
     }
 
-
     private func checkNoInvalidStitchesInNestedArray(pattern: [[String]]) throws -> [[String]] {
         let isEveryStitchValid = validateEachStitchInWholePattern(pattern: pattern)
         switch isEveryStitchValid {
@@ -68,14 +66,14 @@ public class InputValidator {
     }
 
     private func validateEachStitch(stitchRow: [String], rowIndex: Int) -> Result<[String], InputError> {
-        var errorArray:[InputError] = []
+        var errorArray: [InputError] = []
         for (index, stitch) in stitchRow.enumerated() {
-            if (!isStitchValid(stitch: stitch)){
+            if !isStitchValid(stitch: stitch) {
                 errorArray.append(InputError.invalidStitch(invalidStitch: stitchRow[index], rowLocation: index + 1))
             }
         }
 
-        if (errorArray.count > 0) {
+        if errorArray.count > 0 {
             return .failure(InputError.multipleErrors(errors: errorArray))
         }
 
@@ -83,7 +81,7 @@ public class InputValidator {
     }
 
     private func validateEachStitchInWholePattern(pattern: [[String]]) -> Result<[[String]], InputError> {
-        var errorArray:[InputError] = []
+        var errorArray: [InputError] = []
         for (rowIndex, row) in pattern.enumerated() {
             for (stitchIndex, stitch) in row.enumerated() {
                 let result = isStitchAndStitchCountValid(stitch: stitch, rowNumber: rowIndex + 1, stitchIndex: stitchIndex + 1)
@@ -97,14 +95,12 @@ public class InputValidator {
             }
         }
 
-        if (errorArray.count > 0) {
+        if errorArray.count > 0 {
             return .failure(InputError.multipleErrors(errors: errorArray))
         }
 
         return .success(pattern)
     }
-
-
 
     private func validateNoEmptyRows(row: String) -> Result<String, InputError> {
 

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -35,10 +35,10 @@ public class InputValidator {
         for row in pattern {
             let isEmptyRow = validateNoEmptyRows(row: row)
             switch isEmptyRow {
-            case .success:
-                continue
-            case .failure(let error):
-                throw error
+                case .success:
+                    continue
+                case .failure(let error):
+                    throw error
             }
         }
         return pattern
@@ -47,10 +47,10 @@ public class InputValidator {
     private func checkNoInvalidStitchesInNestedArray(pattern: [[String]]) throws -> [[String]] {
         let isEveryStitchValid = validateEachStitchInWholePattern(pattern: pattern)
         switch isEveryStitchValid {
-        case .success:
-            return pattern
-        case .failure(let error):
-            throw error
+            case .success:
+                return pattern
+            case .failure(let error):
+                throw error
         }
 
     }
@@ -58,10 +58,10 @@ public class InputValidator {
     private func checkNoMathematicalIssuesInArrayOfRowInfo(pattern: [RowInfo]) throws -> [RowInfo] {
         let isPatternMathematicallySound = validateEachRowWidth(allRowsMetaData: pattern)
         switch isPatternMathematicallySound {
-        case .success:
-            return pattern
-        case .failure(let error):
-            throw error
+            case .success:
+                return pattern
+            case .failure(let error):
+                throw error
         }
     }
 
@@ -86,10 +86,10 @@ public class InputValidator {
             for (stitchIndex, stitch) in row.enumerated() {
                 let result = isStitchAndStitchCountValid(stitch: stitch, rowNumber: rowIndex + 1, stitchIndex: stitchIndex + 1)
                 switch result {
-                case .success:
-                    continue
-                case .failure(let error):
-                    errorArray.append(error)
+                    case .success:
+                        continue
+                    case .failure(let error):
+                        errorArray.append(error)
                 }
 
             }

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -24,11 +24,13 @@ public class NestedArrayBuilder {
             clipStitch.removeAll(where: { stitchName.contains($0) })
             let stitchNameSuffix = clipStitch
             guard let repeatNumber = Int(stitchNameSuffix) else {
-                throw InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix)
+//                throw InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix)
+                return [stitch]
             }
 
             guard (repeatNumber >= 1) else {
-                throw InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix)
+//                throw InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix)
+                return [stitch]
             }
 
             var stitchArray: [String] = []

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -24,12 +24,10 @@ public class NestedArrayBuilder {
             clipStitch.removeAll(where: { stitchName.contains($0) })
             let stitchNameSuffix = clipStitch
             guard let repeatNumber = Int(stitchNameSuffix) else {
-//                throw InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix)
                 return [stitch]
             }
 
-            guard (repeatNumber >= 1) else {
-//                throw InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix)
+            guard repeatNumber >= 1 else {
                 return [stitch]
             }
 
@@ -37,11 +35,9 @@ public class NestedArrayBuilder {
             stitchArray.append(contentsOf: repeatElement((stitchName + "1"), count: repeatNumber))
             return stitchArray
 
-        }
-        else {
+        } else {
             return[stitch]
         }
     }
-
 
 }

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -21,11 +21,9 @@ let repeatingStitches = allowedStitchesInfo.filter({ $0.canRepeat })
 func getStitchInfo(stitch: String) throws -> StitchType {
     if let lookupStitch = nonrepeatingStitches.first(where: { $0.name == stitch }) {
         return lookupStitch
-    }
-    else if let lookupStitch = repeatingStitches.first(where: { stitch.starts(with: $0.name )}) {
+    } else if let lookupStitch = repeatingStitches.first(where: { stitch.starts(with: $0.name )}) {
         return lookupStitch
-    }
-    else {throw InputError.invalidStitch(invalidStitch: stitch)}
+    } else {throw InputError.invalidStitch(invalidStitch: stitch)}
 
 }
 
@@ -35,7 +33,7 @@ func isStitchValid(stitch: String) -> Bool {
         return true
     } else {
         let stitchNameMatch = repeatingStitches.first(where: { stitch.starts(with: $0.name )})
-        if let stitchFound = stitchNameMatch  {
+        if let stitchFound = stitchNameMatch {
             let stitchName = stitchFound.name
             var clipStitch = stitch
             clipStitch.removeAll(where: { stitchName.contains($0) })
@@ -52,7 +50,7 @@ func isStitchValid(stitch: String) -> Bool {
 }
 
 func isStitchAndStitchCountValid(stitch: String, rowNumber: Int, stitchIndex: Int) -> Result<String, InputError> {
-    if !isStitchValid(stitch: stitch){
+    if !isStitchValid(stitch: stitch) {
         return .failure(InputError.invalidStitch(invalidStitch: stitch, rowLocation: rowNumber, stitchIndexInRow: stitchIndex))
     }
     if nonrepeatingStitches.contains(where: { $0.name == stitch }) {
@@ -68,7 +66,7 @@ func isStitchAndStitchCountValid(stitch: String, rowNumber: Int, stitchIndex: In
             return .failure(InputError.invalidStitchNumber(rowNumber: rowNumber, invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix, stitchIndexInRow: stitchIndex))
         }
 
-        guard (repeatNumber >= 1) else {
+        guard repeatNumber >= 1 else {
             return .failure(InputError.invalidStitchNumber(rowNumber: rowNumber, invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix, stitchIndexInRow: stitchIndex))
         }
 
@@ -76,8 +74,7 @@ func isStitchAndStitchCountValid(stitch: String, rowNumber: Int, stitchIndex: In
         stitchArray.append(contentsOf: repeatElement((stitchName + "1"), count: repeatNumber))
         return .success(stitch)
 
-    }
-    else {
+    } else {
         return .success(stitch)
     }
 }

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -65,11 +65,11 @@ func isStitchAndStitchCountValid(stitch: String, rowNumber: Int, stitchIndex: In
         clipStitch.removeAll(where: { stitchName.contains($0) })
         let stitchNameSuffix = clipStitch
         guard let repeatNumber = Int(stitchNameSuffix) else {
-            return .failure(InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix))
+            return .failure(InputError.invalidStitchNumber(rowNumber: rowNumber, invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix, stitchIndexInRow: stitchIndex))
         }
 
         guard (repeatNumber >= 1) else {
-            return .failure(InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix))
+            return .failure(InputError.invalidStitchNumber(rowNumber: rowNumber, invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix, stitchIndexInRow: stitchIndex))
         }
 
         var stitchArray: [String] = []

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -50,3 +50,34 @@ func isStitchValid(stitch: String) -> Bool {
     }
     return false
 }
+
+func isStitchAndStitchCountValid(stitch: String, rowNumber: Int, stitchIndex: Int) -> Result<String, InputError> {
+    if !isStitchValid(stitch: stitch){
+        return .failure(InputError.invalidStitch(invalidStitch: stitch, rowLocation: rowNumber, stitchIndexInRow: stitchIndex))
+    }
+    if nonrepeatingStitches.contains(where: { $0.name == stitch }) {
+        return .success(stitch)
+    }
+    let isRepeatingStitch = repeatingStitches.first(where: { stitch.starts(with: $0.name )})
+    if let isRepeatingStitch = isRepeatingStitch {
+        let stitchName = isRepeatingStitch.name
+        var clipStitch = stitch
+        clipStitch.removeAll(where: { stitchName.contains($0) })
+        let stitchNameSuffix = clipStitch
+        guard let repeatNumber = Int(stitchNameSuffix) else {
+            return .failure(InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix))
+        }
+
+        guard (repeatNumber >= 1) else {
+            return .failure(InputError.invalidStitchNumber(invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix))
+        }
+
+        var stitchArray: [String] = []
+        stitchArray.append(contentsOf: repeatElement((stitchName + "1"), count: repeatNumber))
+        return .success(stitch)
+
+    }
+    else {
+        return .success(stitch)
+    }
+}

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -50,31 +50,46 @@ func isStitchValid(stitch: String) -> Bool {
 }
 
 func isStitchAndStitchCountValid(stitch: String, rowNumber: Int, stitchIndex: Int) -> Result<String, InputError> {
-    if !isStitchValid(stitch: stitch) {
+    guard isStitchValid(stitch: stitch) else {
         return .failure(InputError.invalidStitch(invalidStitch: stitch, rowLocation: rowNumber, stitchIndexInRow: stitchIndex))
     }
     if nonrepeatingStitches.contains(where: { $0.name == stitch }) {
         return .success(stitch)
     }
-    let isRepeatingStitch = repeatingStitches.first(where: { stitch.starts(with: $0.name )})
-    if let isRepeatingStitch = isRepeatingStitch {
-        let stitchName = isRepeatingStitch.name
-        var clipStitch = stitch
-        clipStitch.removeAll(where: { stitchName.contains($0) })
-        let stitchNameSuffix = clipStitch
-        guard let repeatNumber = Int(stitchNameSuffix) else {
-            return .failure(InputError.invalidStitchNumber(rowNumber: rowNumber, invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix, stitchIndexInRow: stitchIndex))
-        }
-
-        guard repeatNumber >= 1 else {
-            return .failure(InputError.invalidStitchNumber(rowNumber: rowNumber, invalidStitch: stitch, validStitchType: stitchName, invalidStitchNumber: stitchNameSuffix, stitchIndexInRow: stitchIndex))
-        }
-
-        var stitchArray: [String] = []
-        stitchArray.append(contentsOf: repeatElement((stitchName + "1"), count: repeatNumber))
-        return .success(stitch)
-
-    } else {
-        return .success(stitch)
+    else {
+        let isRepeatingStitch = repeatingStitches.first(where: { stitch.starts(with: $0.name )})
+        return determineIfRepeatingStitchIsACorrectRepeatingStitch(stitch: stitch, stitchType: isRepeatingStitch!, rowNumber: rowNumber, stitchIndex: stitchIndex)
     }
+
+}
+
+private func determineIfRepeatingStitchIsACorrectRepeatingStitch(stitch: String, stitchType: StitchType, rowNumber: Int, stitchIndex: Int) -> Result<String, InputError> {
+    let stitchName = stitchType.name
+    var clipStitch = stitch
+    clipStitch.removeAll(where: { stitchName.contains($0) })
+    let stitchNameSuffix = clipStitch
+    guard let repeatNumber = Int(stitchNameSuffix) else {
+        return .failure(InputError.invalidStitchNumber(
+            rowNumber: rowNumber,
+            invalidStitch: stitch,
+            validStitchType: stitchName,
+            invalidStitchNumber: stitchNameSuffix,
+            stitchIndexInRow: stitchIndex
+        ))
+    }
+
+    guard repeatNumber >= 1 else {
+        return .failure(InputError.invalidStitchNumber(
+            rowNumber: rowNumber,
+            invalidStitch: stitch,
+            validStitchType: stitchName,
+            invalidStitchNumber: stitchNameSuffix,
+            stitchIndexInRow: stitchIndex
+        ))
+    }
+
+    var stitchArray: [String] = []
+    stitchArray.append(contentsOf: repeatElement((stitchName + "1"), count: repeatNumber))
+    return .success(stitch)
+
 }

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -14,9 +14,8 @@ class ValidatorTests: XCTestCase {
 
     func testInvalidStitchShouldThrowError() throws {
         let testPattern = ["g1 p1"]
-        let err = InputError.multipleErrors
-        (errors:
-            [
+        let err = InputError.multipleErrors(
+            errors: [
                 SwiftCliCore.InputError.invalidStitch(
                     invalidStitch: "g1",
                     rowLocation: Optional(1),
@@ -87,11 +86,11 @@ class ValidatorTests: XCTestCase {
         let multipleIncorrectStitchesPattern = ["k0 p1"]
         let error = InputError.multipleErrors(errors: [
             InputError.invalidStitchNumber(
-                rowNumber: Optional(1),
+                rowNumber: 1,
                 invalidStitch: "k0",
                 validStitchType: "k",
                 invalidStitchNumber: "0",
-                stitchIndexInRow: Optional(1)
+                stitchIndexInRow: 1
             )
         ])
         expect {

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -14,7 +14,13 @@ class ValidatorTests: XCTestCase {
 
     func testInvalidStitchShouldThrowError() throws {
         let testPattern = ["g1 p1"]
-        let err = InputError.invalidStitch(invalidStitch: "g1", rowLocation: 1)
+        let err = InputError.multipleErrors(errors:
+                                    [
+                                        SwiftCliCore.InputError.invalidStitch(
+                                            invalidStitch: "g1",
+                                            rowLocation: Optional(1),
+                                            stitchIndexInRow: Optional(1))
+                                    ])
         expect {
             try self.inputValidator.validateInput(
                 pattern: testPattern,
@@ -48,6 +54,32 @@ class ValidatorTests: XCTestCase {
         .to(throwError(badCountError))
 
     }
+
+    func testMultipleIncorrectStitchesShouldThrowMultipleErrors() throws {
+        let multipleIncorrectStitchesPattern = ["p1 p1", "g1 p1", "p1 g1", "g1 p1"]
+       let error = InputError.multipleErrors(errors: [
+        InputError.invalidStitch(
+            invalidStitch: "g1",
+            rowLocation: Optional(2),
+            stitchIndexInRow: 1
+        ),
+        InputError.invalidStitch(
+            invalidStitch: "g1",
+            rowLocation: Optional(3),
+            stitchIndexInRow: Optional(2)
+        ),
+        InputError.invalidStitch(
+            invalidStitch: "g1",
+            rowLocation: Optional(4),
+            stitchIndexInRow: Optional(1)
+        )])
+        expect {
+            try self.inputValidator.validateInput(
+                pattern: multipleIncorrectStitchesPattern)
+        }
+        .to(throwError(error))
+    }
+
 
     func testValidPatternShouldReturnMetaData() throws {
 

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -14,13 +14,16 @@ class ValidatorTests: XCTestCase {
 
     func testInvalidStitchShouldThrowError() throws {
         let testPattern = ["g1 p1"]
-        let err = InputError.multipleErrors(errors:
-                                    [
-                                        SwiftCliCore.InputError.invalidStitch(
-                                            invalidStitch: "g1",
-                                            rowLocation: Optional(1),
-                                            stitchIndexInRow: Optional(1))
-                                    ])
+        let err = InputError.multipleErrors
+        (errors:
+            [
+                SwiftCliCore.InputError.invalidStitch(
+                    invalidStitch: "g1",
+                    rowLocation: Optional(1),
+                    stitchIndexInRow: Optional(1)
+                )
+            ]
+        )
         expect {
             try self.inputValidator.validateInput(
                 pattern: testPattern,

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -55,7 +55,7 @@ class ValidatorTests: XCTestCase {
 
     }
 
-    func testMultipleIncorrectStitchesShouldThrowMultipleErrors() throws {
+    func testMultipleIncorrectStitchesTypesShouldThrowMultipleErrors() throws {
         let multipleIncorrectStitchesPattern = ["p1 p1", "g1 p1", "p1 g1", "g1 p1"]
        let error = InputError.multipleErrors(errors: [
         InputError.invalidStitch(
@@ -73,6 +73,24 @@ class ValidatorTests: XCTestCase {
             rowLocation: Optional(4),
             stitchIndexInRow: Optional(1)
         )])
+        expect {
+            try self.inputValidator.validateInput(
+                pattern: multipleIncorrectStitchesPattern)
+        }
+        .to(throwError(error))
+    }
+
+    func testZeroCountStitchShouldThrowMultipleErrors() throws {
+        let multipleIncorrectStitchesPattern = ["k0 p1"]
+        let error = InputError.multipleErrors(errors: [
+            InputError.invalidStitchNumber(
+                rowNumber: Optional(1),
+                invalidStitch: "k0",
+                validStitchType: "k",
+                invalidStitchNumber: "0",
+                stitchIndexInRow: Optional(1)
+            )
+        ])
         expect {
             try self.inputValidator.validateInput(
                 pattern: multipleIncorrectStitchesPattern)

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -98,9 +98,7 @@ class ValidatorTests: XCTestCase {
         .to(throwError(error))
     }
 
-
     func testValidPatternShouldReturnMetaData() throws {
-
 
         let result = try self.inputValidator.validateInput(
             pattern: ["p1 p1", "p1 p1"],

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -59,7 +59,7 @@ class ValidatorTests: XCTestCase {
 
     func testMultipleIncorrectStitchesTypesShouldThrowMultipleErrors() throws {
         let multipleIncorrectStitchesPattern = ["p1 p1", "g1 p1", "p1 g1", "g1 p1"]
-       let error = InputError.multipleErrors(errors: [
+       let expectedErrors = InputError.multipleErrors(errors: [
         InputError.invalidStitch(
             invalidStitch: "g1",
             rowLocation: Optional(2),
@@ -79,12 +79,12 @@ class ValidatorTests: XCTestCase {
             try self.inputValidator.validateInput(
                 pattern: multipleIncorrectStitchesPattern)
         }
-        .to(throwError(error))
+        .to(throwError(expectedErrors))
     }
 
     func testZeroCountStitchShouldThrowMultipleErrors() throws {
         let multipleIncorrectStitchesPattern = ["k0 p1"]
-        let error = InputError.multipleErrors(errors: [
+        let expectedError = InputError.multipleErrors(errors: [
             InputError.invalidStitchNumber(
                 rowNumber: 1,
                 invalidStitch: "k0",
@@ -97,7 +97,7 @@ class ValidatorTests: XCTestCase {
             try self.inputValidator.validateInput(
                 pattern: multipleIncorrectStitchesPattern)
         }
-        .to(throwError(error))
+        .to(throwError(expectedError))
     }
 
     func testValidPatternShouldReturnMetaData() throws {

--- a/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
+++ b/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
@@ -24,29 +24,9 @@ class MultipleStitchExpanderTest: XCTestCase {
         expect(result).to(equal(["k1", "k1", "k1", "k1", "p1"]))
     }
 
-    func testInvalidZeroCountStitch() throws {
-        expect{
-            try NestedArrayBuilder().expandRow(row: ["k0", "p1"])
-        }
-        .to(throwError(
-            InputError.invalidStitchNumber(
-                rowNumber: nil,
-                invalidStitch: "k0",
-                validStitchType: "k",
-                invalidStitchNumber: "0")
-        ))
-    }
 
-    func testInvalidWordCountStitch() throws {
-        expect{
-            try NestedArrayBuilder().expandRow(row: ["kx", "py"])
-        }
-        .to(throwError(
-            InputError.invalidStitchNumber(
-                    rowNumber: nil,
-                    invalidStitch: "kx",
-                    validStitchType: "k",
-                    invalidStitchNumber: "x")
-        ))
+    func testExpandInvalidMultipleStitch() throws {
+        let result = try NestedArrayBuilder().expandRow(row: ["k0", "p1"])
+        expect(result).to(equal(["k0", "p1"]))
     }
 }

--- a/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
+++ b/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
@@ -24,7 +24,6 @@ class MultipleStitchExpanderTest: XCTestCase {
         expect(result).to(equal(["k1", "k1", "k1", "k1", "p1"]))
     }
 
-
     func testExpandInvalidMultipleStitch() throws {
         let result = try NestedArrayBuilder().expandRow(row: ["k0", "p1"])
         expect(result).to(equal(["k0", "p1"]))

--- a/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
+++ b/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
@@ -24,8 +24,8 @@ class MultipleStitchExpanderTest: XCTestCase {
         expect(result).to(equal(["k1", "k1", "k1", "k1", "p1"]))
     }
 
-    func testExpandInvalidMultipleStitch() throws {
-        let result = try NestedArrayBuilder().expandRow(row: ["k0", "p1"])
-        expect(result).to(equal(["k0", "p1"]))
+    func testValidNonExpandingStitchesDontExpand() throws {
+        let result = try NestedArrayBuilder().expandRow(row: ["k1", "p1"])
+        expect(result).to(equal(["k1", "p1"]))
     }
 }


### PR DESCRIPTION
Added new method `InputValidator.validateEachStitchInWholePattern` which is called to find both stitch count errors and invalid stitch type errors.

Removed multiple-stitch error checking from `NestedArrayBuilder` and adjusted `NestedArrayBuilder` tests accordingly.

Added new func `isStitchAndStitchCountValid` in StitchLibrary.swift which returns a result with an `InputError` of type `invalidStitchNumber` or `invalidStitch` which is called in `InputValidator`.
