### PR TITLE
Fix --stitches message about allowed file types that include brackets

### DIFF
--- a/Sources/SwiftCli/main.swift
+++ b/Sources/SwiftCli/main.swift
@@ -18,7 +18,6 @@ struct StartProgram: ParsableCommand {
     @Flag(help: "Call this for info about the stitches you are allowed to use.")
     var stitches = false
 
-
     func run() {
         let patternNormalizer = PatternNormalizer()
         let nestedArrayBuilder = NestedArrayBuilder()
@@ -57,7 +56,6 @@ struct StartProgram: ParsableCommand {
                 knitFlat: knitFlat
             )
         }
-
 
     }
 }

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -8,7 +8,6 @@ public final class Chartify {
     var fileValidator: FileValidator
     var outputWriter: OutputWriter
 
-
     public init(
         inputValidator: InputValidator,
         chartConstructor: ChartConstructor,

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -3,7 +3,6 @@ import Foundation
 enum InputError: Error, Equatable {
     case emptyRow
 
-
     case invalidStitch(invalidStitch: String, rowLocation: Int? = nil, stitchIndexInRow: Int? = nil)
     case invalidRowWidth(
         invalidRowNumber: Int,
@@ -117,7 +116,6 @@ func invalidStitchWithLocationError(invalidStitch: String, rowLocation: Int?, st
 
 }
 
-
 func invalidStitchNumberError(rowNumber: Int?, invalidStitch: String, validStitchType: String, invalidStitchCount: String, stitchIndexInRow: Int?) -> String {
     var onRow = ""
     var atIndex = ""
@@ -132,7 +130,6 @@ func invalidStitchNumberError(rowNumber: Int?, invalidStitch: String, validStitc
     Invalid Stitch Count Error:
     '\(invalidStitch)'\(atIndex)\(onRow) starts with valid stitch type \(validStitchType) but ends with the invalid stitch count \(invalidStitchCount). Please enter a positive integer number of stitches.
     """
-
 
 }
 

--- a/Sources/SwiftCliCore/FileWriter.swift
+++ b/Sources/SwiftCliCore/FileWriter.swift
@@ -5,7 +5,6 @@ public class FileWriter: OutputWriter {
     var filePath: String
     var fileName: String
 
-
     public init(filePath: String, fileName: String) {
         self.filePath = filePath
         self.fileName = fileName

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -17,9 +17,7 @@ public class InputValidator {
 
         try checkNoEmptyRowsInArrayOfStrings(pattern: lowercaseNormalizedPattern)
 
-
         var patternNestedArray =  try lowercaseNormalizedPattern.map { try nestedArrayBuilder.arrayMaker(row: $0) }
-
 
         if knitFlat == true {
 
@@ -79,7 +77,6 @@ private func validateEachStitch(stitchRow: [String], rowIndex: Int) -> Result<[S
             errorArray.append(InputError.invalidStitch(invalidStitch: stitchRow[index], rowLocation: index + 1))
         }
     }
-
 
     if errorArray.count > 0 {
         return .failure(InputError.multipleErrors(errors: errorArray))
@@ -151,4 +148,3 @@ public func knitFlatArray(array: [[String]]) -> [[String]] {
     }
     return flatArray
 }
-

--- a/Sources/SwiftCliCore/InstructionsGiver.swift
+++ b/Sources/SwiftCliCore/InstructionsGiver.swift
@@ -10,7 +10,6 @@ public class InstructionsGiver {
     }
     public func giveInstructions() throws {
 
-
         var message = """
 Chartify takes in written patterns, either on the command line or in allowed file types, and returns charts.
 

--- a/Sources/SwiftCliCore/InstructionsGiver.swift
+++ b/Sources/SwiftCliCore/InstructionsGiver.swift
@@ -9,11 +9,17 @@ public class InstructionsGiver {
         self.fileValidator = fileValidator
     }
     public func giveInstructions() throws {
-        let allowedFileTypes = fileValidator.allowedFileTypes
+
+
         var message = """
-Chartify takes in written patterns, either on the command line or in \(allowedFileTypes) files, and returns charts.
-Current allowed stitches are listed below.\n
+Chartify takes in written patterns, either on the command line or in allowed file types, and returns charts.
+
+Allowed file types include:\n
 """
+        for filetype in fileValidator.allowedFileTypes { message.append(filetype + "\n") }
+        message.append("""
+\nCurrent allowed stitches are listed below.\n\n
+""")
         message.append("Repeating stitches (can be written with any number 1 or greater afterwards: \n")
         for stitch in repeatingStitches {
             message.append(stitch.name + "\n")

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -16,12 +16,12 @@ public class NestedArrayBuilder {
 
     private func handleRepeats(row: [String]) throws -> [String] {
 
-        var repeatedRow:[String] = []
-        var currentRowSection:[String] = []
-        for (index, stitch) in row.enumerated(){
-            if let repeats = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)){
+        var repeatedRow: [String] = []
+        var currentRowSection: [String] = []
+        for (index, stitch) in row.enumerated() {
+            if let repeats = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
                 let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
-                guard (numberOfRepeats! >= 1) else {
+                guard numberOfRepeats! >= 1 else {
                     throw InputError.invalidRepeatCount
 
                 }

--- a/Sources/SwiftCliCore/StitchLibrary.swift
+++ b/Sources/SwiftCliCore/StitchLibrary.swift
@@ -55,8 +55,7 @@ func isStitchAndStitchCountValid(stitch: String, rowNumber: Int, stitchIndex: In
     }
     if nonrepeatingStitches.contains(where: { $0.name == stitch }) {
         return .success(stitch)
-    }
-    else {
+    } else {
         let isRepeatingStitch = repeatingStitches.first(where: { stitch.starts(with: $0.name )})
         return determineIfRepeatingStitchIsACorrectRepeatingStitch(stitch: stitch, stitchType: isRepeatingStitch!, rowNumber: rowNumber, stitchIndex: stitchIndex)
     }


### PR DESCRIPTION
Add new and improved message to `InstructionsGiver`. Take away the previous version included an array clumsily and thoughtlessly cast to a string in the middle of a message to the user. 