### PR TITLE
Multiple error messages2

### DIFF
--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -45,8 +45,8 @@ public final class Chartify {
 
     private func validateAndChartify(pattern: [String], knitFlat: Bool) throws -> String {
         let metaData = try inputValidator.validateInput(pattern: pattern, knitFlat: knitFlat)
-        return (chartConstructor.makeChart(patternMetaData: metaData))
-
+        //return (chartConstructor.makeChart(patternMetaData: metaData))
+        return "placeholder"
     }
 
 }

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -48,11 +48,11 @@ public final class Chartify {
                 guard errors.isEmpty else {
                     errors.forEach { error in
                         print("\(error.localizedDescription)")
-                    }
+                    } 
                     return
 
                     }
-                var chart = chartConstructor.makeChart(patternMetaData: patternOrErrors.arrayOfRowInfo)
+                let chart = chartConstructor.makeChart(patternMetaData: patternOrErrors.arrayOfRowInfo)
                 do { try outputWriter.writeOutput(output: chart)
                     return
                 } catch {
@@ -61,12 +61,6 @@ public final class Chartify {
                 }
 
             }
-    private func validateAndChartify(pattern: [String], knitFlat: Bool) throws -> String {
-        let metaData = inputValidator.validateInput(pattern: pattern, knitFlat: knitFlat)
-        //return (chartConstructor.makeChart(patternMetaData: metaData))
-        return "placeholder"
-    }
-
 
     }
 

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -52,7 +52,8 @@ public final class Chartify {
 
         }
         let chart = chartConstructor.makeChart(patternMetaData: patternOrErrors.arrayOfRowInfo)
-        do { try outputWriter.writeOutput(output: chart)
+        do {
+            try outputWriter.writeOutput(output: chart)
             return
         } catch {
             print(error.localizedDescription)

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -33,20 +33,40 @@ public final class Chartify {
             }
         } else { patternToProcess = userInput }
 
-        do {
-            let chart = try validateAndChartify(pattern: patternToProcess, knitFlat: knitFlat)
-            try outputWriter.writeOutput(output: chart)
-        } catch {
-            print(error.localizedDescription)
-            return
-        }
 
-    }
+            let patternOrErrors = inputValidator.validateInput(pattern: patternToProcess, knitFlat: knitFlat)
+            var errors: [InputError] = []
+            for result in patternOrErrors.results{
+                switch result{
+                case .success:
+                    continue
+                case .failure(let error):
+                    errors.append(error)
+                }
+            }
 
+                guard errors.isEmpty else {
+                    errors.forEach { error in
+                        print("\(error.localizedDescription)")
+                    }
+                    return
+
+                    }
+                var chart = chartConstructor.makeChart(patternMetaData: patternOrErrors.arrayOfRowInfo)
+                do { try outputWriter.writeOutput(output: chart)
+                    return
+                } catch {
+                    print(error.localizedDescription)
+                    return
+                }
+
+            }
     private func validateAndChartify(pattern: [String], knitFlat: Bool) throws -> String {
-        let metaData = try inputValidator.validateInput(pattern: pattern, knitFlat: knitFlat)
+        let metaData = inputValidator.validateInput(pattern: pattern, knitFlat: knitFlat)
         //return (chartConstructor.makeChart(patternMetaData: metaData))
         return "placeholder"
     }
 
-}
+
+    }
+

--- a/Sources/SwiftCliCore/Chartify.swift
+++ b/Sources/SwiftCliCore/Chartify.swift
@@ -33,34 +33,32 @@ public final class Chartify {
             }
         } else { patternToProcess = userInput }
 
-
-            let patternOrErrors = inputValidator.validateInput(pattern: patternToProcess, knitFlat: knitFlat)
-            var errors: [InputError] = []
-            for result in patternOrErrors.results{
-                switch result{
-                case .success:
-                    continue
-                case .failure(let error):
-                    errors.append(error)
-                }
+        let patternOrErrors = inputValidator.validateInput(pattern: patternToProcess, knitFlat: knitFlat)
+        var errors: [InputError] = []
+        for result in patternOrErrors.results {
+            switch result {
+            case .success:
+                continue
+            case .failure(let error):
+                errors.append(error)
             }
+        }
 
-                guard errors.isEmpty else {
-                    errors.forEach { error in
-                        print("\(error.localizedDescription)")
-                    } 
-                    return
-
-                    }
-                let chart = chartConstructor.makeChart(patternMetaData: patternOrErrors.arrayOfRowInfo)
-                do { try outputWriter.writeOutput(output: chart)
-                    return
-                } catch {
-                    print(error.localizedDescription)
-                    return
-                }
-
+        guard errors.isEmpty else {
+            errors.forEach { error in
+                print("\(error.localizedDescription)")
             }
+            return
+
+        }
+        let chart = chartConstructor.makeChart(patternMetaData: patternOrErrors.arrayOfRowInfo)
+        do { try outputWriter.writeOutput(output: chart)
+            return
+        } catch {
+            print(error.localizedDescription)
+            return
+        }
 
     }
 
+}

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 enum InputError: Error, Equatable {
-    case emptyRow
-
+    case emptyRow(row: Int? = nil)
     case invalidStitch(invalidStitch: String, rowLocation: Int? = nil, stitchIndexInRow: Int? = nil)
     case invalidRowWidth(
         invalidRowNumber: Int,

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -1,8 +1,12 @@
 import Foundation
 
 enum InputError: Error, Equatable {
-    case emptyRow(row: Int? = nil)
-    case invalidStitch(invalidStitch: String, rowLocation: Int? = nil, stitchIndexInRow: Int? = nil)
+    case emptyRow(row: Int)
+    case invalidStitch(
+        invalidStitch: String,
+        rowLocation: Int? = nil,
+        stitchIndexInRow: Int? = nil
+    )
     case invalidRowWidth(
         invalidRowNumber: Int,
         expectedStitchCount: Int,
@@ -17,9 +21,9 @@ enum InputError: Error, Equatable {
     )
     case multipleErrors(errors: [InputError])
     case invalidRepeatCount(
-        rowNumber: Int? = nil,
-        stitchIndexInRow: Int? = nil,
-        invalidRepeat: String? = nil
+        rowNumber: Int,
+        stitchIndexInRow: Int,
+        invalidRepeat: String
     )
 
 }
@@ -86,15 +90,11 @@ func allowedStitches() -> String {
     return allowedStitchesMessage
 }
 
-func emptyRowError(row: Int? = nil) -> String {
-    var onRow = ""
-    if let row = row {
-        onRow = " on row \(row)"
-    }
+func emptyRowError(row: Int) -> String {
     return """
     Empty Row Error:
     All rows must contain stitches.
-    You have submitted an empty row\(onRow).
+    You have submitted an empty row on row \(row).
     """
 }
 

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -16,15 +16,19 @@ enum InputError: Error, Equatable {
         stitchIndexInRow: Int? = nil
     )
     case multipleErrors(errors: [InputError])
-    case invalidRepeatCount
+    case invalidRepeatCount(
+        rowNumber: Int? = nil,
+        stitchIndexInRow: Int? = nil,
+        invalidRepeat: String? = nil
+    )
 
 }
 
 extension InputError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .emptyRow:
-            return emptyRowError()
+        case .emptyRow(let row):
+            return emptyRowError(row:row)
         case .invalidStitch(let invalidStitch, let rowLocation, let stitchIndexInRow):
             return invalidStitchWithLocationError(
                 invalidStitch: invalidStitch,
@@ -46,8 +50,13 @@ extension InputError: LocalizedError {
                 stitchIndexInRow: stitchIndexInRow
             )
 
-        case .invalidRepeatCount:
-            return("Stitch repeat number must be at least 1.")
+        case .invalidRepeatCount(let rowNumber, let stitchIndexInRow, let invalidRepeat):
+            return invalidRepeatCountError(
+                rowNumber: rowNumber,
+                stitchIndexInRow: stitchIndexInRow,
+                invalidRepeat: invalidRepeat
+            )
+
 
         case .multipleErrors(let errors):
             return multipleErrorsMessage(errors: errors)
@@ -78,11 +87,15 @@ func allowedStitches() -> String {
     return allowedStitchesMessage
 }
 
-func emptyRowError() -> String {
+func emptyRowError(row: Int? = nil) -> String {
+    var onRow = ""
+    if let row = row {
+        onRow = " on row \(row)"
+    }
     return """
     Empty Row Error:
     All rows must contain stitches.
-    You have submitted an empty string for at least one row.
+    You have submitted an empty row\(onRow).
     """
 }
 
@@ -140,4 +153,25 @@ func multipleErrorsMessage(errors: [InputError]) -> String {
     }
     return allErrorMessages
 
+}
+
+func invalidRepeatCountError(rowNumber: Int? = nil, stitchIndexInRow: Int? = nil, invalidRepeat: String? = nil ) -> String {
+    var onRow = ""
+    var atIndex = ""
+    var badRepeatString  = ""
+    if let rowNumber = rowNumber {
+        onRow = " on row \(rowNumber)"
+    }
+    if let stitchIndexInRow = stitchIndexInRow {
+        atIndex = " at index \(stitchIndexInRow)"
+    }
+    if let invalidRepeat = invalidRepeat {
+        badRepeatString = "'\(invalidRepeat)'"
+    }
+
+    return """
+    Invalid Stitch Count Error:
+    One of your repeat notations \(badRepeatString)\(atIndex)\(onRow) has an invalid stitch count.
+    Stitch repeat number must be at least 1.
+    """
 }

--- a/Sources/SwiftCliCore/Errors.swift
+++ b/Sources/SwiftCliCore/Errors.swift
@@ -28,7 +28,7 @@ extension InputError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .emptyRow(let row):
-            return emptyRowError(row:row)
+            return emptyRowError(row: row)
         case .invalidStitch(let invalidStitch, let rowLocation, let stitchIndexInRow):
             return invalidStitchWithLocationError(
                 invalidStitch: invalidStitch,
@@ -56,7 +56,6 @@ extension InputError: LocalizedError {
                 stitchIndexInRow: stitchIndexInRow,
                 invalidRepeat: invalidRepeat
             )
-
 
         case .multipleErrors(let errors):
             return multipleErrorsMessage(errors: errors)

--- a/Sources/SwiftCliCore/FileWriter.swift
+++ b/Sources/SwiftCliCore/FileWriter.swift
@@ -4,19 +4,18 @@ public class FileWriter: OutputWriter {
 
     var filePath: String
 
-
     public init(filePath: String) {
 
         self.filePath = filePath
-      
+
     }
 
     public func writeOutput(output: String) throws {
 
         do {
             try output.write(toFile: filePath + ".txt",
-                            atomically: true,
-                            encoding: .utf8)
+                             atomically: true,
+                             encoding: .utf8)
         } catch {
             throw error
         }

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PatternDataAndPossibleErrors: Equatable{
+public struct PatternDataAndPossibleErrors: Equatable {
     var arrayOfStrings: [String] = []
     var arrayOfArrays: [[String]] = []
     var arrayOfRowInfo: [RowInfo] = []
@@ -40,10 +40,7 @@ public class InputValidator {
 
         patternAndErrorResults.results.append(checkNoInvalidStitchesInNestedArray(pattern: patternAndErrorResults.arrayOfArrays))
 
-
         patternAndErrorResults.results.append(checkRepeats(pattern: patternAndErrorResults.arrayOfArrays))
-
-
 
         for result in patternAndErrorResults.results {
             switch result {
@@ -55,160 +52,152 @@ public class InputValidator {
 
         }
 
-
         patternAndErrorResults.arrayOfArrays = patternAndErrorResults.arrayOfArrays.map { nestedArrayBuilder.expandRow(row: $0) }
         patternAndErrorResults.arrayOfRowInfo = MetaDataBuilder().buildAllMetaData(stitchArray: patternAndErrorResults.arrayOfArrays)
         patternAndErrorResults.results.append(checkNoMathematicalIssuesInArrayOfRowInfo(pattern: patternAndErrorResults.arrayOfRowInfo))
         return patternAndErrorResults
 
-
     }
 
-
-
-
-
-private func checkNoEmptyRowsInArrayOfStrings(pattern: [String]) -> [Result<Success, InputError>] {
-    var results: [Result<Success, InputError>] = []
-    var anyerrors = false
-    for (index, row) in pattern.enumerated(){
-        if row.isEmpty{
-            results.append(.failure(InputError.emptyRow(row: index + 1)))
-            anyerrors = true
-        } else {
-            continue
-        }
-        }
-    guard !anyerrors else {
-        return(results)
-    }
-    results.append(.success(Success.patternArray(pattern)))
-    return(results)
-    }
-
-
-private func checkNoInvalidStitchesInNestedArray(pattern: [[String]]) -> Result<Success, InputError> {
-    let isEveryStitchValid = validateEachStitchInWholePattern(pattern: pattern)
-    switch isEveryStitchValid {
-    case .success:
-        return .success(Success.patternNestedArray(pattern))
-    case .failure(let error):
-        return .failure(error)
-    }
-
-}
-
-private func checkNoMathematicalIssuesInArrayOfRowInfo(pattern: [RowInfo]) -> Result<Success, InputError> {
-    let isPatternMathematicallySound = validateEachRowWidth(allRowsMetaData: pattern)
-    switch isPatternMathematicallySound {
-    case .success:
-        return .success(Success.patternRowInfo(pattern))
-    case .failure(let error):
-        return .failure(error)
-    }
-}
-
-private func validateEachStitch(stitchRow: [String], rowIndex: Int) -> Result<[String], InputError> {
-
-    var errorArray: [InputError] = []
-    for (index, stitch) in stitchRow.enumerated() {
-        if !isStitchValid(stitch: stitch) {
-            errorArray.append(InputError.invalidStitch(invalidStitch: stitchRow[index], rowLocation: index + 1))
-        }
-    }
-
-    if errorArray.count > 0 {
-        return .failure(InputError.multipleErrors(errors: errorArray))
-    }
-
-    return .success(stitchRow)
-}
-
-private func validateEachStitchInWholePattern(pattern: [[String]]) -> Result<[[String]], InputError> {
-    var errorArray: [InputError] = []
-    for (rowIndex, row) in pattern.enumerated() {
-        for (stitchIndex, stitch) in row.enumerated() {
-            let result = isStitchAndStitchCountValid(stitch: stitch, rowNumber: rowIndex + 1, stitchIndex: stitchIndex + 1)
-            switch result {
-            case .success:
-                continue
-            case .failure(let error):
-                if let _ = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)){
-                    continue
-                }
-                else {errorArray.append(error)}
-            }
-
-        }
-    }
-
-    if errorArray.count > 0 {
-        return .failure(InputError.multipleErrors(errors: errorArray))
-    }
-
-    return .success(pattern)
-}
-
-private func validateNoEmptyRows(row: String) -> Result<String, InputError> {
-
-    guard !row.isEmpty else {
-        return .failure(InputError.emptyRow())
-    }
-    return .success(row)
-}
-
-private func validateEachRowWidth(allRowsMetaData: [RowInfo]) -> Result<[RowInfo], InputError> {
-    let numberOfRowsToCheck = (allRowsMetaData.count) - 1
-    if numberOfRowsToCheck == 0 {
-        return .success(allRowsMetaData)
-    }
-    for rowNum in 1...numberOfRowsToCheck {
-        let prevRow = allRowsMetaData[rowNum-1]
-        var currentRow = allRowsMetaData[rowNum]
-        if !isCurrentRowStitchCountValid(prevRow: prevRow, currentRow: currentRow) {
-            let expectedNextRowWidth = prevRow.width + currentRow.leftIncDec + currentRow.rightIncDec
-            return .failure(InputError.invalidRowWidth(
-                invalidRowNumber: currentRow.userRowNumber,
-                expectedStitchCount: expectedNextRowWidth,
-                actualCount: currentRow.width
-            ))
-        }
-    }
-    return .success(allRowsMetaData)
-}
-
-private func isCurrentRowStitchCountValid(prevRow: RowInfo, currentRow: RowInfo) -> Bool {
-    let expectedCurrentRowWidth = prevRow.width + currentRow.leftIncDec + currentRow.rightIncDec
-    return expectedCurrentRowWidth == currentRow.width
-}
-
-public func knitFlatArray(array: [[String]]) -> [[String]] {
-    let numberofRows = array.count
-    var flatArray = array
-    for rowNum in 0..<numberofRows where rowNum % 2 == 1 {
-        flatArray[rowNum].reverse()
-    }
-    return flatArray
-}
-
-private func checkRepeats(pattern: [[String]]) -> Result<Success, InputError> {
-
-    for (rowIndex, row) in pattern.enumerated() {
-        for (stitchIndex, stitch) in row.enumerated() {
-            if let _ = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
-                let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
-                guard numberOfRepeats! >= 1 else {
-                    return .failure(InputError.invalidRepeatCount(rowNumber: rowIndex + 1,
-                                                                stitchIndexInRow: stitchIndex + 1,
-                                                                  invalidRepeat: stitch
-                                                                 ))
-                }
-
+    private func checkNoEmptyRowsInArrayOfStrings(pattern: [String]) -> [Result<Success, InputError>] {
+        var results: [Result<Success, InputError>] = []
+        var anyerrors = false
+        for (index, row) in pattern.enumerated() {
+            if row.isEmpty {
+                results.append(.failure(InputError.emptyRow(row: index + 1)))
+                anyerrors = true
             } else {
                 continue
             }
         }
+        guard !anyerrors else {
+            return(results)
+        }
+        results.append(.success(Success.patternArray(pattern)))
+        return(results)
     }
-    return .success(Success.patternNestedArray(pattern))
+
+    private func checkNoInvalidStitchesInNestedArray(pattern: [[String]]) -> Result<Success, InputError> {
+        let isEveryStitchValid = validateEachStitchInWholePattern(pattern: pattern)
+        switch isEveryStitchValid {
+        case .success:
+            return .success(Success.patternNestedArray(pattern))
+        case .failure(let error):
+            return .failure(error)
+        }
+
+    }
+
+    private func checkNoMathematicalIssuesInArrayOfRowInfo(pattern: [RowInfo]) -> Result<Success, InputError> {
+        let isPatternMathematicallySound = validateEachRowWidth(allRowsMetaData: pattern)
+        switch isPatternMathematicallySound {
+        case .success:
+            return .success(Success.patternRowInfo(pattern))
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    private func validateEachStitch(stitchRow: [String], rowIndex: Int) -> Result<[String], InputError> {
+
+        var errorArray: [InputError] = []
+        for (index, stitch) in stitchRow.enumerated() {
+            if !isStitchValid(stitch: stitch) {
+                errorArray.append(InputError.invalidStitch(invalidStitch: stitchRow[index], rowLocation: index + 1))
+            }
+        }
+
+        if errorArray.count > 0 {
+            return .failure(InputError.multipleErrors(errors: errorArray))
+        }
+
+        return .success(stitchRow)
+    }
+
+    private func validateEachStitchInWholePattern(pattern: [[String]]) -> Result<[[String]], InputError> {
+        var errorArray: [InputError] = []
+        for (rowIndex, row) in pattern.enumerated() {
+            for (stitchIndex, stitch) in row.enumerated() {
+                let result = isStitchAndStitchCountValid(stitch: stitch, rowNumber: rowIndex + 1, stitchIndex: stitchIndex + 1)
+                switch result {
+                case .success:
+                    continue
+                case .failure(let error):
+                    if let _ = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
+                        continue
+                    } else {errorArray.append(error)}
+                }
+
+            }
+        }
+
+        if errorArray.count > 0 {
+            return .failure(InputError.multipleErrors(errors: errorArray))
+        }
+
+        return .success(pattern)
+    }
+
+    private func validateNoEmptyRows(row: String) -> Result<String, InputError> {
+
+        guard !row.isEmpty else {
+            return .failure(InputError.emptyRow())
+        }
+        return .success(row)
+    }
+
+    private func validateEachRowWidth(allRowsMetaData: [RowInfo]) -> Result<[RowInfo], InputError> {
+        let numberOfRowsToCheck = (allRowsMetaData.count) - 1
+        if numberOfRowsToCheck == 0 {
+            return .success(allRowsMetaData)
+        }
+        for rowNum in 1...numberOfRowsToCheck {
+            let prevRow = allRowsMetaData[rowNum-1]
+            var currentRow = allRowsMetaData[rowNum]
+            if !isCurrentRowStitchCountValid(prevRow: prevRow, currentRow: currentRow) {
+                let expectedNextRowWidth = prevRow.width + currentRow.leftIncDec + currentRow.rightIncDec
+                return .failure(InputError.invalidRowWidth(
+                    invalidRowNumber: currentRow.userRowNumber,
+                    expectedStitchCount: expectedNextRowWidth,
+                    actualCount: currentRow.width
+                ))
+            }
+        }
+        return .success(allRowsMetaData)
+    }
+
+    private func isCurrentRowStitchCountValid(prevRow: RowInfo, currentRow: RowInfo) -> Bool {
+        let expectedCurrentRowWidth = prevRow.width + currentRow.leftIncDec + currentRow.rightIncDec
+        return expectedCurrentRowWidth == currentRow.width
+    }
+
+    public func knitFlatArray(array: [[String]]) -> [[String]] {
+        let numberofRows = array.count
+        var flatArray = array
+        for rowNum in 0..<numberofRows where rowNum % 2 == 1 {
+            flatArray[rowNum].reverse()
+        }
+        return flatArray
+    }
+
+    private func checkRepeats(pattern: [[String]]) -> Result<Success, InputError> {
+
+        for (rowIndex, row) in pattern.enumerated() {
+            for (stitchIndex, stitch) in row.enumerated() {
+                if let _ = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
+                    let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
+                    guard numberOfRepeats! >= 1 else {
+                        return .failure(InputError.invalidRepeatCount(rowNumber: rowIndex + 1,
+                                                                      stitchIndexInRow: stitchIndex + 1,
+                                                                      invalidRepeat: stitch
+                                                                     ))
+                    }
+
+                } else {
+                    continue
+                }
+            }
+        }
+        return .success(Success.patternNestedArray(pattern))
     }
 }

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -13,6 +13,7 @@ extension Array{
 public struct PatternDataAndPossibleErrors: Equatable{
     var arrayOfStrings: [String] = []
     var arrayOfArrays: [[String]] = []
+    var expandedArrayOfArrays: [[String]] = []
     var arrayOfRowInfo: [RowInfo] = []
     var results: [Result<Success, InputError>] = []
 }
@@ -21,7 +22,6 @@ public enum Success: Equatable {
     case patternArray(_ input: [String])
     case patternNestedArray(_ input: [[String]])
     case patternRowInfo(_ input: [RowInfo])
-
 }
 
 public class InputValidator {
@@ -43,20 +43,23 @@ public class InputValidator {
 
         patternAndErrorResults.results  += checkNoEmptyRowsInArrayOfStrings(pattern: patternAndErrorResults.arrayOfStrings)
 
-//
-//        var patternNestedArray: [[String]]
-//        do { patternNestedArray =  try patternAndErrorResults.arrayOfStrings.map { try nestedArrayBuilder.arrayMaker(row: $0) } }  catch { print("todo")  }
-//
-//        if knitFlat == true {
-//
-//            patternNestedArray = knitFlatArray(array: patternNestedArray)
-//        }
-//
-//        do { try checkNoInvalidStitchesInNestedArray(pattern: patternNestedArray)} catch { print("todo") }
-//
-//        var expandedNestedArray: [[String]]
-//        do { expandedNestedArray = try patternNestedArray.map { try nestedArrayBuilder.expandRow(row: $0) } } catch {print("todo")}
-//
+
+        patternAndErrorResults.arrayOfArrays =  patternAndErrorResults.arrayOfStrings.map { nestedArrayBuilder.arrayMaker(row: $0) } 
+
+        if knitFlat == true {
+            patternAndErrorResults.arrayOfArrays = knitFlatArray(array: patternAndErrorResults.arrayOfArrays)
+        }
+
+        patternAndErrorResults.results.append(checkNoInvalidStitchesInNestedArray(pattern: patternAndErrorResults.arrayOfArrays))
+
+        // check for no incorrect (10x)
+
+        // expand k6 and 10x, if
+
+
+//        patternAndErrorResults.expandedArrayOfArrays = try patternAndErrorResults.arrayOfArrays.map { try nestedArrayBuilder.expandRow(row: $0) } }
+
+
 //        let patternMetaData = MetaDataBuilder().buildAllMetaData(stitchArray: expandedNestedArray)
 //
 //        do { try checkNoMathematicalIssuesInArrayOfRowInfo(pattern: patternMetaData)} catch {print("todo")}
@@ -76,13 +79,13 @@ private func checkNoEmptyRowsInArrayOfStrings(pattern: [String]) -> [Result<Succ
 }
     return results
 }
-private func checkNoInvalidStitchesInNestedArray(pattern: [[String]]) throws -> [[String]] {
+private func checkNoInvalidStitchesInNestedArray(pattern: [[String]]) -> Result<Success, InputError> {
     let isEveryStitchValid = validateEachStitchInWholePattern(pattern: pattern)
     switch isEveryStitchValid {
     case .success:
-        return pattern
+        return .success(Success.patternNestedArray(pattern))
     case .failure(let error):
-        throw error
+        return .failure(error)
     }
 
 }

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -179,10 +179,13 @@ public class InputValidator {
                 if let _ = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
                     let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
                     guard numberOfRepeats! >= 1 else {
-                        return .failure(InputError.invalidRepeatCount(rowNumber: rowIndex + 1,
-                                                                      stitchIndexInRow: stitchIndex + 1,
-                                                                      invalidRepeat: stitch
-                                                                     ))
+                        return .failure(
+                            InputError.invalidRepeatCount(
+                                rowNumber: rowIndex + 1,
+                                stitchIndexInRow: stitchIndex + 1,
+                                invalidRepeat: stitch
+                            )
+                        )
                     }
 
                 } else {

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -138,14 +138,6 @@ public class InputValidator {
         return .success(pattern)
     }
 
-    private func validateNoEmptyRows(row: String) -> Result<String, InputError> {
-
-        guard !row.isEmpty else {
-            return .failure(InputError.emptyRow())
-        }
-        return .success(row)
-    }
-
     private func validateEachRowWidth(allRowsMetaData: [RowInfo]) -> Result<[RowInfo], InputError> {
         let numberOfRowsToCheck = (allRowsMetaData.count) - 1
         if numberOfRowsToCheck == 0 {

--- a/Sources/SwiftCliCore/InputValidator.swift
+++ b/Sources/SwiftCliCore/InputValidator.swift
@@ -60,8 +60,7 @@ public class InputValidator {
 
         patternAndErrorResults.arrayOfArrays = patternAndErrorResults.arrayOfArrays.map { nestedArrayBuilder.expandRow(row: $0) }
         patternAndErrorResults.arrayOfRowInfo = MetaDataBuilder().buildAllMetaData(stitchArray: patternAndErrorResults.arrayOfArrays)
-
-                do { try checkNoMathematicalIssuesInArrayOfRowInfo(pattern: patternAndErrorResults.arrayOfRowInfo)} catch {print("todo")}
+        patternAndErrorResults.results.append(checkNoMathematicalIssuesInArrayOfRowInfo(pattern: patternAndErrorResults.arrayOfRowInfo))
         return patternAndErrorResults
 
 

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -6,18 +6,15 @@ public class NestedArrayBuilder {
     public func arrayMaker(row: String) -> [String] {
         let substringRowStitches = row.split(separator: " ")
         let rowStitches = substringRowStitches.map {(String($0))}
-        //let expandedRowStitches = try handleRepeats(row: rowStitches)
+        // let expandedRowStitches = try handleRepeats(row: rowStitches)
         return(rowStitches)
     }
 
-    public func expandRow(row: [String])  ->  [String] {
+    public func expandRow(row: [String]) -> [String] {
         var rowWithExpandedMultipleStitches: [String] = []
-        do { try rowWithExpandedMultipleStitches = row.flatMap { try getMultipleStitchInfo(stitch: $0) } }  catch { return row }
-        do { return try handleRepeats(row: rowWithExpandedMultipleStitches) }  catch { return rowWithExpandedMultipleStitches }
+        do { try rowWithExpandedMultipleStitches = row.flatMap { try getMultipleStitchInfo(stitch: $0) } } catch { return row }
+        do { return try handleRepeats(row: rowWithExpandedMultipleStitches) } catch { return rowWithExpandedMultipleStitches }
     }
-
-
-
 
     private func handleRepeats(row: [String]) throws -> [String] {
 

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -20,7 +20,7 @@ public class NestedArrayBuilder {
 
         var repeatedRow: [String] = []
         var currentRowSection: [String] = []
-        for (index, stitch) in row.enumerated() {
+        for (_, stitch) in row.enumerated() {
             if let _ = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
                 let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
                 guard numberOfRepeats! >= 1 else {

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -24,10 +24,10 @@ public class NestedArrayBuilder {
         var repeatedRow: [String] = []
         var currentRowSection: [String] = []
         for (index, stitch) in row.enumerated() {
-            if let repeats = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
+            if let _ = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
                 let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
                 guard numberOfRepeats! >= 1 else {
-                    throw InputError.invalidRepeatCount
+                    throw InputError.invalidRepeatCount()
 
                 }
                 for _ in 1...numberOfRepeats! { repeatedRow += currentRowSection }

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -6,13 +6,19 @@ public class NestedArrayBuilder {
     public func arrayMaker(row: String) -> [String] {
         let substringRowStitches = row.split(separator: " ")
         let rowStitches = substringRowStitches.map {(String($0))}
-        // let expandedRowStitches = try handleRepeats(row: rowStitches)
         return(rowStitches)
     }
 
     public func expandRow(row: [String]) -> [String] {
         var rowWithExpandedMultipleStitches: [String] = []
-        do { try rowWithExpandedMultipleStitches = row.flatMap { try getMultipleStitchInfo(stitch: $0) } } catch { return row }
+        do {
+            try rowWithExpandedMultipleStitches = row.flatMap {
+                try getMultipleStitchInfo(stitch: $0)
+            }
+
+        } catch {
+            return row
+        }
         do { return try handleRepeats(row: rowWithExpandedMultipleStitches) } catch { return rowWithExpandedMultipleStitches }
     }
 
@@ -24,7 +30,7 @@ public class NestedArrayBuilder {
             if let _ = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
                 let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
                 guard numberOfRepeats! >= 1 else {
-                    throw InputError.invalidRepeatCount()
+                    continue
 
                 }
                 for _ in 1...numberOfRepeats! { repeatedRow += currentRowSection }

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -10,27 +10,13 @@ public class NestedArrayBuilder {
         return(rowStitches)
     }
 
-    public func expandRow(row: [String]) throws ->  [String] {
-        return try row.flatMap { try getMultipleStitchInfo(stitch: $0) }
+    public func expandRow(row: [String])  ->  [String] {
+        var rowWithExpandedMultipleStitches: [String] = []
+        do { try rowWithExpandedMultipleStitches = row.flatMap { try getMultipleStitchInfo(stitch: $0) } }  catch { return row }
+        do { return try handleRepeats(row: rowWithExpandedMultipleStitches) }  catch { return rowWithExpandedMultipleStitches }
     }
 
-    public func checkRepeats(pattern: [[String]]) -> Result<Success, InputError> {
 
-        for (index, row) in pattern.enumerated() {
-        for (index, stitch) in row.enumerated() {
-            if let repeats = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
-                let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
-                guard numberOfRepeats! >= 1 else {
-                    return .failure(InputError.invalidRepeatCount)
-                }
-
-            } else {
-                continue
-            }
-        }
-        }
-        return .success(Success.patternNestedArray(pattern))
-    }
 
 
     private func handleRepeats(row: [String]) throws -> [String] {

--- a/Sources/SwiftCliCore/NestedArrayBuilder.swift
+++ b/Sources/SwiftCliCore/NestedArrayBuilder.swift
@@ -3,16 +3,35 @@ import Foundation
 public class NestedArrayBuilder {
     public init() {}
 
-    public func arrayMaker(row: String) throws -> [String] {
+    public func arrayMaker(row: String) -> [String] {
         let substringRowStitches = row.split(separator: " ")
         let rowStitches = substringRowStitches.map {(String($0))}
-        let expandedRowStitches = try handleRepeats(row: rowStitches)
-        return(expandedRowStitches)
+        //let expandedRowStitches = try handleRepeats(row: rowStitches)
+        return(rowStitches)
     }
 
     public func expandRow(row: [String]) throws ->  [String] {
         return try row.flatMap { try getMultipleStitchInfo(stitch: $0) }
     }
+
+    public func checkRepeats(pattern: [[String]]) -> Result<Success, InputError> {
+
+        for (index, row) in pattern.enumerated() {
+        for (index, stitch) in row.enumerated() {
+            if let repeats = (stitch.range(of: "^[(0-9x)]*$", options: .regularExpression)) {
+                let numberOfRepeats = Int(stitch.components(separatedBy: CharacterSet.decimalDigits.inverted).joined())
+                guard numberOfRepeats! >= 1 else {
+                    return .failure(InputError.invalidRepeatCount)
+                }
+
+            } else {
+                continue
+            }
+        }
+        }
+        return .success(Success.patternNestedArray(pattern))
+    }
+
 
     private func handleRepeats(row: [String]) throws -> [String] {
 

--- a/Tests/SwiftCliCoreTests/ChartifyTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartifyTest.swift
@@ -4,19 +4,19 @@ import Nimble
 @testable import SwiftCliCore
 
 class ChartifyFinishedTest: XCTestCase {
-//    func testRunCallsValidator() throws {
-//        let mock = MockInputValidator(patternNormalizer: PatternNormalizer(), nestedArrayBuilder: NestedArrayBuilder())
-//
-//        Chartify(
-//            inputValidator: mock,
-//            chartConstructor: ChartConstructor(),
-//            fileValidator: FileValidator(),
-//            outputWriter: ConsoleWriter()
-//        ).run(userInput: ["k1 k1 k1", "k1 k1 k1"], knitFlat: false)
-//
-//        expect(mock.wasValidatorCalled).to(equal(true))
-//    }
-    
+    func testRunCallsValidator() throws {
+        let mock = MockInputValidator(patternNormalizer: PatternNormalizer(), nestedArrayBuilder: NestedArrayBuilder())
+
+        Chartify(
+            inputValidator: mock,
+            chartConstructor: ChartConstructor(),
+            fileValidator: FileValidator(),
+            outputWriter: ConsoleWriter()
+        ).run(userInput: ["k1 k1 k1", "k1 k1 k1"], knitFlat: false)
+
+        expect(mock.wasValidatorCalled).to(equal(true))
+    }
+
     func testRunCallsMakeChartIfInputIsValid() throws {
         let mock = MockChartConstructor()
 
@@ -63,7 +63,45 @@ class MockInputValidator: InputValidator {
     override func validateInput(pattern: [String], knitFlat: Bool) -> PatternDataAndPossibleErrors {
 
         wasValidatorCalled = true
-        return PatternDataAndPossibleErrors()}
+        return PatternDataAndPossibleErrors(
+            arrayOfStrings: ["p1 p1"],
+            arrayOfArrays: [["p1", "p1"]],
+            arrayOfRowInfo: [
+                SwiftCliCore.RowInfo(
+                    row: ["p1", "p1"],
+                    rowIndex: 0,
+                    bottomLine: "└─┴─┘",
+                    stitchSymbols: "│-│-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0)
+            ],
+            results: [
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternArray(["p1 p1"])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternRowInfo(
+                    [
+                        SwiftCliCore.RowInfo(
+                            row: ["p1", "p1"],
+                            rowIndex: 0,
+                            bottomLine: "└─┴─┘",
+                            stitchSymbols: "│-│-│\n",
+                            width: 2,
+                            patternRowsCount: 0,
+                            leftIncDec: 0,
+                            rightIncDec: 0,
+                            leftOffset: 0,
+                            transRowLeftOffset: 0)
+                    ]
+                ))
+            ]
+        )
+    }
+
 }
 
 class MockChartConstructor: ChartConstructor {

--- a/Tests/SwiftCliCoreTests/ChartifyTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartifyTest.swift
@@ -4,18 +4,19 @@ import Nimble
 @testable import SwiftCliCore
 
 class ChartifyFinishedTest: XCTestCase {
-    func testRunCallsValidator() throws {
-        let mock = MockInputValidator(patternNormalizer: PatternNormalizer(), nestedArrayBuilder: NestedArrayBuilder())
-
-        Chartify(
-            inputValidator: mock,
-            chartConstructor: ChartConstructor(),
-            fileValidator: FileValidator(),
-            outputWriter: ConsoleWriter()
-        ).run(userInput: ["k1"], knitFlat: false)
-
-        expect(mock.wasValidatorCalled).to(equal(true))
-    }
+//    func testRunCallsValidator() throws {
+//        let mock = MockInputValidator(patternNormalizer: PatternNormalizer(), nestedArrayBuilder: NestedArrayBuilder())
+//
+//        Chartify(
+//            inputValidator: mock,
+//            chartConstructor: ChartConstructor(),
+//            fileValidator: FileValidator(),
+//            outputWriter: ConsoleWriter()
+//        ).run(userInput: ["k1 k1 k1", "k1 k1 k1"], knitFlat: false)
+//
+//        expect(mock.wasValidatorCalled).to(equal(true))
+//    }
+    
     func testRunCallsMakeChartIfInputIsValid() throws {
         let mock = MockChartConstructor()
 
@@ -59,7 +60,7 @@ class ChartifyFinishedTest: XCTestCase {
 class MockInputValidator: InputValidator {
     var wasValidatorCalled = false
 
-    override func validateInput(pattern: [String], knitFlat: Bool)  -> PatternDataAndPossibleErrors {
+    override func validateInput(pattern: [String], knitFlat: Bool) -> PatternDataAndPossibleErrors {
 
         wasValidatorCalled = true
         return PatternDataAndPossibleErrors()}

--- a/Tests/SwiftCliCoreTests/ChartifyTest.swift
+++ b/Tests/SwiftCliCoreTests/ChartifyTest.swift
@@ -59,19 +59,10 @@ class ChartifyFinishedTest: XCTestCase {
 class MockInputValidator: InputValidator {
     var wasValidatorCalled = false
 
-    override func validateInput(pattern: [String], knitFlat: Bool) throws -> [RowInfo] {
+    override func validateInput(pattern: [String], knitFlat: Bool)  -> PatternDataAndPossibleErrors {
 
         wasValidatorCalled = true
-        return [RowInfo(
-            row: ["p1", "p1"],
-            rowIndex: 0,
-            bottomLine: "└─┴─┘",
-            stitchSymbols: "│-│-│\n",
-            width: 2,
-            leftIncDec: 0,
-            rightIncDec: 0,
-            leftOffset: 0
-        )]}
+        return PatternDataAndPossibleErrors()}
 }
 
 class MockChartConstructor: ChartConstructor {

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -23,8 +23,8 @@ class ValidatorTests: XCTestCase {
             arrayOfArrays: [["p1", "p1"], []],
             arrayOfRowInfo: [],
             results: [
-                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: Optional(2))),
-                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], []])),
+                Result.failure(SwiftCliCore.InputError.emptyRow(row: 2)),
+                Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], []])),
                 Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], []]))
             ]
         )
@@ -109,7 +109,7 @@ class ValidatorTests: XCTestCase {
             arrayOfArrays: [[], ["g1", "p1"], ["p1", "g1"]],
             arrayOfRowInfo: [],
             results: [
-                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: Optional(1))),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: 1)),
                 Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(
                     SwiftCliCore.InputError.multipleErrors(
                         errors: [

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -23,7 +23,7 @@ class ValidatorTests: XCTestCase {
             arrayOfArrays: [["p1", "p1"], []],
             arrayOfRowInfo: [],
             results: [
-                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: nil)),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: Optional(2))),
                 Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], []])),
                 Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], []]))
             ]
@@ -109,7 +109,7 @@ class ValidatorTests: XCTestCase {
             arrayOfArrays: [[], ["g1", "p1"], ["p1", "g1"]],
             arrayOfRowInfo: [],
             results: [
-                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: nil)),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: Optional(1))),
                 Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(
                     SwiftCliCore.InputError.multipleErrors(
                         errors: [

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -12,93 +12,65 @@ class ValidatorTests: XCTestCase {
         inputValidator = InputValidator(patternNormalizer: PatternNormalizer(), nestedArrayBuilder: NestedArrayBuilder())
     }
 
-    func testInvalidStitchShouldThrowError() throws {
-        let testPattern = ["g1 p1"]
-        let err = InputError.multipleErrors(
-            errors: [
-                SwiftCliCore.InputError.invalidStitch(
-                    invalidStitch: "g1",
-                    rowLocation: Optional(1),
-                    stitchIndexInRow: Optional(1)
-                )
-            ]
-        )
-        expect {
-            try self.inputValidator.validateInput(
-                pattern: testPattern,
-                knitFlat: false)
-        }
-        .to(throwError(err))
-
-    }
-
     func testEmptyRowShouldThrowError() throws {
         let testPattern = ["p1 p1", ""]
-        expect {
-            try self.inputValidator.validateInput(
-                pattern: testPattern)
-
-        }
-        .to(throwError(InputError.emptyRow))
+        let result = self.inputValidator.validateInput(
+            pattern: testPattern,
+            knitFlat: false
+        )
+        let expectedResult = PatternDataAndPossibleErrors(
+            arrayOfStrings: ["todo"],
+            results: [
+            .failure(InputError.emptyRow()),
+            .success(Success.patternNestedArray([[],["p1", "p1"]])),
+            .success(Success.patternNestedArray([[],["p1", "p1"]])),
+            .success(Success.patternNestedArray([[],["p1", "p1"]]))
+        ])
+        expect(result).to(equal(expectedResult))
     }
+
+    func testInvalidStitchShouldThrowError() throws {
+        let testPattern = ["g1 p1"]
+        let result = self.inputValidator.validateInput(
+            pattern: testPattern,
+            knitFlat: false
+        )
+        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+        expect(result).to(equal(expectedResult))
+
+    }
+
 
     func testInvalidStitchCountShouldThrowError() throws {
         let badCountPattern = ["p1 p1", "p1 p1", "p1 p1", "p1 p1 p1"]
-
-        let badCountError = InputError.invalidRowWidth(
-            invalidRowNumber: 4,
-            expectedStitchCount: 2,
-            actualCount: 3)
-        expect {
-            try self.inputValidator.validateInput(
-                pattern: badCountPattern)
-        }
-        .to(throwError(badCountError))
+        let result = self.inputValidator.validateInput(
+            pattern: badCountPattern,
+            knitFlat: false
+        )
+        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+        expect(result).to(equal(expectedResult))
 
     }
 
     func testMultipleIncorrectStitchesTypesShouldThrowMultipleErrors() throws {
         let multipleIncorrectStitchesPattern = ["p1 p1", "g1 p1", "p1 g1", "g1 p1"]
-       let expectedErrors = InputError.multipleErrors(errors: [
-        InputError.invalidStitch(
-            invalidStitch: "g1",
-            rowLocation: Optional(2),
-            stitchIndexInRow: 1
-        ),
-        InputError.invalidStitch(
-            invalidStitch: "g1",
-            rowLocation: Optional(3),
-            stitchIndexInRow: Optional(2)
-        ),
-        InputError.invalidStitch(
-            invalidStitch: "g1",
-            rowLocation: Optional(4),
-            stitchIndexInRow: Optional(1)
-        )])
-        expect {
-            try self.inputValidator.validateInput(
-                pattern: multipleIncorrectStitchesPattern)
-        }
-        .to(throwError(expectedErrors))
+        let result = self.inputValidator.validateInput(
+            pattern: multipleIncorrectStitchesPattern,
+            knitFlat: false
+        )
+        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+        expect(result).to(equal(expectedResult))
     }
 
 
     func testZeroCountStitchShouldThrowMultipleErrors() throws {
-        let multipleIncorrectStitchesPattern = ["k0 p1"]
-        let expectedError = InputError.multipleErrors(errors: [
-            InputError.invalidStitchNumber(
-                rowNumber: 1,
-                invalidStitch: "k0",
-                validStitchType: "k",
-                invalidStitchNumber: "0",
-                stitchIndexInRow: 1
-            )
-        ])
-        expect {
-            try self.inputValidator.validateInput(
-                pattern: multipleIncorrectStitchesPattern)
-        }
-        .to(throwError(expectedError))
+        let zeroCountStitchesPattern = ["k0 p1"]
+        let result = self.inputValidator.validateInput(
+            pattern: zeroCountStitchesPattern,
+            knitFlat: false
+        )
+        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+        expect(result).to(equal(expectedResult))
     }
 
     func testValidPatternShouldReturnMetaData() throws {
@@ -108,29 +80,29 @@ class ValidatorTests: XCTestCase {
             pattern: ["p1 p1", "p1 p1"],
             knitFlat: false
         )
-
-        let expectedResult = [
-            RowInfo(
-                row: ["p1", "p1"],
-                rowIndex: 0,
-                bottomLine: "└─┴─┘",
-                stitchSymbols: "│-│-│\n",
-                width: 2,
-                leftIncDec: 0,
-                rightIncDec: 0,
-                leftOffset: 0
-            ),
-            RowInfo(
-                row: ["p1", "p1"],
-                rowIndex: 1,
-                bottomLine: "├─┼─┤\n",
-                stitchSymbols: "│-│-│\n",
-                width: 2,
-                leftIncDec: 0,
-                rightIncDec: 0,
-                leftOffset: 0
-            )
-        ]
+        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+//        let expectedResult = [
+//            RowInfo(
+//                row: ["p1", "p1"],
+//                rowIndex: 0,
+//                bottomLine: "└─┴─┘",
+//                stitchSymbols: "│-│-│\n",
+//                width: 2,
+//                leftIncDec: 0,
+//                rightIncDec: 0,
+//                leftOffset: 0
+//            ),
+//            RowInfo(
+//                row: ["p1", "p1"],
+//                rowIndex: 1,
+//                bottomLine: "├─┼─┤\n",
+//                stitchSymbols: "│-│-│\n",
+//                width: 2,
+//                leftIncDec: 0,
+//                rightIncDec: 0,
+//                leftOffset: 0
+//            )
+//        ]
         expect(result).to(equal(expectedResult))
     }
 
@@ -140,29 +112,30 @@ class ValidatorTests: XCTestCase {
             pattern: ["k1 p1", "p1 k1"],
             knitFlat: true
         )
+        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
 
-        let expectedResult = [
-            RowInfo(
-                row: ["k1", "p1"],
-                rowIndex: 0,
-                bottomLine: "└─┴─┘",
-                stitchSymbols: "│ │-│\n",
-                width: 2,
-                leftIncDec: 0,
-                rightIncDec: 0,
-                leftOffset: 0
-            ),
-            RowInfo(
-                row: ["k1", "p1"],
-                rowIndex: 1,
-                bottomLine: "├─┼─┤\n",
-                stitchSymbols: "│ │-│\n",
-                width: 2,
-                leftIncDec: 0,
-                rightIncDec: 0,
-                leftOffset: 0
-            )
-        ]
+//        let expectedResult = [
+//            RowInfo(
+//                row: ["k1", "p1"],
+//                rowIndex: 0,
+//                bottomLine: "└─┴─┘",
+//                stitchSymbols: "│ │-│\n",
+//                width: 2,
+//                leftIncDec: 0,
+//                rightIncDec: 0,
+//                leftOffset: 0
+//            ),
+//            RowInfo(
+//                row: ["k1", "p1"],
+//                rowIndex: 1,
+//                bottomLine: "├─┼─┤\n",
+//                stitchSymbols: "│ │-│\n",
+//                width: 2,
+//                leftIncDec: 0,
+//                rightIncDec: 0,
+//                leftOffset: 0
+//            )
+//        ]
         expect(result).to(equal(expectedResult))
     }
 
@@ -170,28 +143,29 @@ class ValidatorTests: XCTestCase {
         let result = try self.inputValidator.validateInput(
             pattern: ["K1 P1", "P1 K1"]
         )
-        let expectedResult = [
-            RowInfo(
-                row: ["k1", "p1"],
-                rowIndex: 0,
-                bottomLine: "└─┴─┘",
-                stitchSymbols: "│ │-│\n",
-                width: 2,
-                leftIncDec: 0,
-                rightIncDec: 0,
-                leftOffset: 0
-            ),
-            RowInfo(
-                row: ["p1", "k1"],
-                rowIndex: 1,
-                bottomLine: "├─┼─┤\n",
-                stitchSymbols: "│-│ │\n",
-                width: 2,
-                leftIncDec: 0,
-                rightIncDec: 0,
-                leftOffset: 0
-            )
-        ]
+        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+//        let expectedResult = [
+//            RowInfo(
+//                row: ["k1", "p1"],
+//                rowIndex: 0,
+//                bottomLine: "└─┴─┘",
+//                stitchSymbols: "│ │-│\n",
+//                width: 2,
+//                leftIncDec: 0,
+//                rightIncDec: 0,
+//                leftOffset: 0
+//            ),
+//            RowInfo(
+//                row: ["p1", "k1"],
+//                rowIndex: 1,
+//                bottomLine: "├─┼─┤\n",
+//                stitchSymbols: "│-│ │\n",
+//                width: 2,
+//                leftIncDec: 0,
+//                rightIncDec: 0,
+//                leftOffset: 0
+//            )
+//        ]
         expect(result).to(equal(expectedResult))
     }
 }

--- a/Tests/SwiftCliCoreTests/InputValidatorTest.swift
+++ b/Tests/SwiftCliCoreTests/InputValidatorTest.swift
@@ -19,13 +19,15 @@ class ValidatorTests: XCTestCase {
             knitFlat: false
         )
         let expectedResult = PatternDataAndPossibleErrors(
-            arrayOfStrings: ["todo"],
+            arrayOfStrings: ["p1 p1", ""],
+            arrayOfArrays: [["p1", "p1"], []],
+            arrayOfRowInfo: [],
             results: [
-            .failure(InputError.emptyRow()),
-            .success(Success.patternNestedArray([[],["p1", "p1"]])),
-            .success(Success.patternNestedArray([[],["p1", "p1"]])),
-            .success(Success.patternNestedArray([[],["p1", "p1"]]))
-        ])
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: nil)),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], []])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], []]))
+            ]
+        )
         expect(result).to(equal(expectedResult))
     }
 
@@ -35,137 +37,324 @@ class ValidatorTests: XCTestCase {
             pattern: testPattern,
             knitFlat: false
         )
-        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+        let expectedResult = PatternDataAndPossibleErrors(
+            arrayOfStrings: ["g1 p1"],
+            arrayOfArrays: [["g1", "p1"]],
+            arrayOfRowInfo: [],
+            results: [
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternArray(["g1 p1"])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.multipleErrors(errors: [
+                    SwiftCliCore.InputError.invalidStitch(invalidStitch: "g1", rowLocation: Optional(1), stitchIndexInRow: Optional(1))
+                ])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["g1", "p1"]]))])
         expect(result).to(equal(expectedResult))
 
     }
 
 
     func testInvalidStitchCountShouldThrowError() throws {
-        let badCountPattern = ["p1 p1", "p1 p1", "p1 p1", "p1 p1 p1"]
+        let badCountPattern = ["p1 p1", "p1 p1 p1"]
         let result = self.inputValidator.validateInput(
             pattern: badCountPattern,
             knitFlat: false
         )
-        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+        let expectedResult = PatternDataAndPossibleErrors(
+            arrayOfStrings: ["p1 p1", "p1 p1 p1"],
+            arrayOfArrays: [["p1", "p1"], ["p1", "p1", "p1"]],
+            arrayOfRowInfo: [
+                SwiftCliCore.RowInfo(
+                    row: ["p1", "p1"],
+                    rowIndex: 0,
+                    bottomLine: "└─┴─┘",
+                    stitchSymbols: "│-│-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0
+                ),
+                SwiftCliCore.RowInfo(
+                    row: ["p1", "p1", "p1"],
+                    rowIndex: 1,
+                    bottomLine: "├─┼─┼─┤\n",
+                    stitchSymbols: "│-│-│-│\n",
+                    width: 3,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0
+                )
+            ],
+            results: [
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternArray(["p1 p1", "p1 p1 p1"])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], ["p1", "p1", "p1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], ["p1", "p1", "p1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.invalidRowWidth(invalidRowNumber: 2, expectedStitchCount: 2, actualCount: 3))
+            ]
+        )
         expect(result).to(equal(expectedResult))
 
     }
 
-    func testMultipleIncorrectStitchesTypesShouldThrowMultipleErrors() throws {
-        let multipleIncorrectStitchesPattern = ["p1 p1", "g1 p1", "p1 g1", "g1 p1"]
+    func testMultipleIncorrectStitchesTypesAndEmptyRowShouldThrowMultipleErrors() throws {
+        let multipleIncorrectStitchesPattern = ["", "g1 p1", "p1 g1"]
         let result = self.inputValidator.validateInput(
             pattern: multipleIncorrectStitchesPattern,
             knitFlat: false
         )
-        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+        let expectedResult = PatternDataAndPossibleErrors(
+            arrayOfStrings: ["", "g1 p1", "p1 g1"],
+            arrayOfArrays: [[], ["g1", "p1"], ["p1", "g1"]],
+            arrayOfRowInfo: [],
+            results: [
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.emptyRow(row: nil)),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(
+                    SwiftCliCore.InputError.multipleErrors(
+                        errors: [
+                            SwiftCliCore.InputError.invalidStitch(invalidStitch: "g1", rowLocation: Optional(2), stitchIndexInRow: Optional(1)),
+                            SwiftCliCore.InputError.invalidStitch(invalidStitch: "g1", rowLocation: Optional(3), stitchIndexInRow: Optional(2))
+                        ]
+                    )
+                ),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([[], ["g1", "p1"], ["p1", "g1"]]))])
         expect(result).to(equal(expectedResult))
     }
 
 
-    func testZeroCountStitchShouldThrowMultipleErrors() throws {
+    func testZeroCountStitchShouldThrowOneError() throws {
         let zeroCountStitchesPattern = ["k0 p1"]
         let result = self.inputValidator.validateInput(
             pattern: zeroCountStitchesPattern,
             knitFlat: false
         )
-        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
+        let expectedResult = PatternDataAndPossibleErrors(
+            arrayOfStrings: ["k0 p1"],
+            arrayOfArrays: [["k0", "p1"]],
+            arrayOfRowInfo: [],
+            results: [
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternArray(["k0 p1"])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.failure(SwiftCliCore.InputError.multipleErrors(
+                    errors: [
+                        SwiftCliCore.InputError.invalidStitchNumber(
+                            rowNumber: Optional(1),
+                            invalidStitch: "k0",
+                            validStitchType: "k",
+                            invalidStitchNumber: "0",
+                            stitchIndexInRow: Optional(1)
+                        )
+                    ]
+                )),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["k0", "p1"]]))
+            ]
+        )
         expect(result).to(equal(expectedResult))
     }
 
-    func testValidPatternShouldReturnMetaData() throws {
+    func testValidPatternShouldReturnAllSuccesses() throws {
 
 
-        let result = try self.inputValidator.validateInput(
+        let result = self.inputValidator.validateInput(
             pattern: ["p1 p1", "p1 p1"],
             knitFlat: false
         )
-        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
-//        let expectedResult = [
-//            RowInfo(
-//                row: ["p1", "p1"],
-//                rowIndex: 0,
-//                bottomLine: "└─┴─┘",
-//                stitchSymbols: "│-│-│\n",
-//                width: 2,
-//                leftIncDec: 0,
-//                rightIncDec: 0,
-//                leftOffset: 0
-//            ),
-//            RowInfo(
-//                row: ["p1", "p1"],
-//                rowIndex: 1,
-//                bottomLine: "├─┼─┤\n",
-//                stitchSymbols: "│-│-│\n",
-//                width: 2,
-//                leftIncDec: 0,
-//                rightIncDec: 0,
-//                leftOffset: 0
-//            )
-//        ]
+        let expectedResult = PatternDataAndPossibleErrors(
+            arrayOfStrings: ["p1 p1", "p1 p1"],
+            arrayOfArrays: [["p1", "p1"], ["p1", "p1"]],
+            arrayOfRowInfo: [
+                SwiftCliCore.RowInfo(
+                    row: ["p1", "p1"],
+                    rowIndex: 0,
+                    bottomLine: "└─┴─┘",
+                    stitchSymbols: "│-│-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0
+),
+                SwiftCliCore.RowInfo(
+                    row: ["p1", "p1"],
+                    rowIndex: 1,
+                    bottomLine: "├─┼─┤\n",
+                    stitchSymbols: "│-│-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0
+                )
+            ],
+            results: [
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternArray(["p1 p1", "p1 p1"])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], ["p1", "p1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["p1", "p1"], ["p1", "p1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternRowInfo([
+                    SwiftCliCore.RowInfo(
+                        row: ["p1", "p1"],
+                        rowIndex: 0,
+                        bottomLine: "└─┴─┘",
+                        stitchSymbols: "│-│-│\n",
+                        width: 2,
+                        patternRowsCount: 0,
+                        leftIncDec: 0,
+                        rightIncDec: 0,
+                        leftOffset: 0,
+                        transRowLeftOffset: 0
+                    ),
+                    SwiftCliCore.RowInfo(
+                        row: ["p1", "p1"],
+                        rowIndex: 1,
+                        bottomLine: "├─┼─┤\n",
+                        stitchSymbols: "│-│-│\n",
+                        width: 2,
+                        patternRowsCount: 0,
+                        leftIncDec: 0,
+                        rightIncDec: 0,
+                        leftOffset: 0,
+                        transRowLeftOffset: 0
+                    )
+                ]))])
         expect(result).to(equal(expectedResult))
     }
 
     func testValidPatternKnitFlatShouldReturnMetaData() throws {
 
-        let result = try self.inputValidator.validateInput(
+        let result = self.inputValidator.validateInput(
             pattern: ["k1 p1", "p1 k1"],
             knitFlat: true
         )
-        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
-
-//        let expectedResult = [
-//            RowInfo(
-//                row: ["k1", "p1"],
-//                rowIndex: 0,
-//                bottomLine: "└─┴─┘",
-//                stitchSymbols: "│ │-│\n",
-//                width: 2,
-//                leftIncDec: 0,
-//                rightIncDec: 0,
-//                leftOffset: 0
-//            ),
-//            RowInfo(
-//                row: ["k1", "p1"],
-//                rowIndex: 1,
-//                bottomLine: "├─┼─┤\n",
-//                stitchSymbols: "│ │-│\n",
-//                width: 2,
-//                leftIncDec: 0,
-//                rightIncDec: 0,
-//                leftOffset: 0
-//            )
-//        ]
+        let expectedResult = PatternDataAndPossibleErrors(
+            arrayOfStrings: ["k1 p1", "p1 k1"],
+            arrayOfArrays: [["k1", "p1"], ["k1", "p1"]],
+            arrayOfRowInfo: [
+                SwiftCliCore.RowInfo(
+                    row: ["k1", "p1"],
+                    rowIndex: 0,
+                    bottomLine: "└─┴─┘",
+                    stitchSymbols: "│ │-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0
+                ),
+                SwiftCliCore.RowInfo(
+                    row: ["k1", "p1"],
+                    rowIndex: 1,
+                    bottomLine: "├─┼─┤\n",
+                    stitchSymbols: "│ │-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0
+                )
+            ],
+            results: [
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternArray(["k1 p1", "p1 k1"])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["k1", "p1"], ["k1", "p1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["k1", "p1"], ["k1", "p1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternRowInfo(
+                    [
+                SwiftCliCore.RowInfo(
+                    row: ["k1", "p1"],
+                    rowIndex: 0,
+                    bottomLine: "└─┴─┘",
+                    stitchSymbols: "│ │-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0
+                ),
+                SwiftCliCore.RowInfo(
+                    row: ["k1", "p1"],
+                    rowIndex: 1,
+                    bottomLine: "├─┼─┤\n",
+                    stitchSymbols: "│ │-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0
+                )
+            ]
+                )
+                                                                                   )
+            ]
+        )
         expect(result).to(equal(expectedResult))
     }
 
     func testValidPatternWithUpperCaseShouldReturnMetaData() throws {
-        let result = try self.inputValidator.validateInput(
+        let result = self.inputValidator.validateInput(
             pattern: ["K1 P1", "P1 K1"]
         )
-        let expectedResult = PatternDataAndPossibleErrors(arrayOfStrings: ["todo"])
-//        let expectedResult = [
-//            RowInfo(
-//                row: ["k1", "p1"],
-//                rowIndex: 0,
-//                bottomLine: "└─┴─┘",
-//                stitchSymbols: "│ │-│\n",
-//                width: 2,
-//                leftIncDec: 0,
-//                rightIncDec: 0,
-//                leftOffset: 0
-//            ),
-//            RowInfo(
-//                row: ["p1", "k1"],
-//                rowIndex: 1,
-//                bottomLine: "├─┼─┤\n",
-//                stitchSymbols: "│-│ │\n",
-//                width: 2,
-//                leftIncDec: 0,
-//                rightIncDec: 0,
-//                leftOffset: 0
-//            )
-//        ]
+        let expectedResult = PatternDataAndPossibleErrors(
+            arrayOfStrings: ["k1 p1", "p1 k1"],
+            arrayOfArrays: [["k1", "p1"], ["p1", "k1"]],
+            arrayOfRowInfo: [
+                SwiftCliCore.RowInfo(
+                    row: ["k1", "p1"],
+                    rowIndex: 0,
+                    bottomLine: "└─┴─┘",
+                    stitchSymbols: "│ │-│\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0),
+                SwiftCliCore.RowInfo(
+                    row: ["p1", "k1"],
+                    rowIndex: 1,
+                    bottomLine: "├─┼─┤\n",
+                    stitchSymbols: "│-│ │\n",
+                    width: 2,
+                    patternRowsCount: 0,
+                    leftIncDec: 0,
+                    rightIncDec: 0,
+                    leftOffset: 0,
+                    transRowLeftOffset: 0)],
+            results: [
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternArray(["k1 p1", "p1 k1"])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["k1", "p1"], ["p1", "k1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternNestedArray([["k1", "p1"], ["p1", "k1"]])),
+                Swift.Result<SwiftCliCore.Success, SwiftCliCore.InputError>.success(SwiftCliCore.Success.patternRowInfo(
+                    [
+                        SwiftCliCore.RowInfo(
+                            row: ["k1", "p1"],
+                            rowIndex: 0,
+                            bottomLine: "└─┴─┘",
+                            stitchSymbols: "│ │-│\n",
+                            width: 2,
+                            patternRowsCount: 0,
+                            leftIncDec: 0,
+                            rightIncDec: 0,
+                            leftOffset: 0,
+                            transRowLeftOffset: 0
+                        ),
+                        SwiftCliCore.RowInfo(
+                            row: ["p1", "k1"],
+                            rowIndex: 1,
+                            bottomLine: "├─┼─┤\n",
+                            stitchSymbols: "│-│ │\n",
+                            width: 2,
+                            patternRowsCount: 0,
+                            leftIncDec: 0,
+                            rightIncDec: 0,
+                            leftOffset: 0,
+                            transRowLeftOffset: 0
+                        )
+                    ]))])
         expect(result).to(equal(expectedResult))
     }
 }

--- a/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
+++ b/Tests/SwiftCliCoreTests/NestedArrayBuilderTest.swift
@@ -6,85 +6,35 @@ import Nimble
 class NestedArrayMakerTest: XCTestCase {
 
     func testNestedArrayBuilderEmpty() throws {
-        let result = try NestedArrayBuilder().arrayMaker(row: "")
+        let result = NestedArrayBuilder().arrayMaker(row: "")
         expect(result).to(equal([]))
     }
 
     func testNestedArrayBuilder() throws {
-        let result = try NestedArrayBuilder().arrayMaker(row: "k1 k1 k1")
+        let result = NestedArrayBuilder().arrayMaker(row: "k1 k1 k1")
         expect(result).to(equal(["k1", "k1", "k1"]))
     }
 
-    func testNestedArrayBuilderWithRepeats() throws {
-        let result = try NestedArrayBuilder().arrayMaker(row: "k1 p1 (2x)")
-        expect(result).to(equal(["k1", "p1", "k1", "p1"]))
-    }
-
-    func testNestedArrayBuilderWithRepeatsMidRow() throws {
-        let result = try NestedArrayBuilder().arrayMaker(row: "k1 p1 (2x) yo k1")
-        expect(result).to(equal(["k1", "p1", "k1", "p1", "yo", "k1"]))
-    }
-
-    func testNestedArrayBuilderWithMultipleRepeats() throws {
-        let result = try NestedArrayBuilder().arrayMaker(row: "k1 p1 (3x) k1 yo k1 (2x) k1 p1 (3x)")
-        expect(result).to(equal(["k1", "p1", "k1", "p1", "k1", "p1", "k1", "yo", "k1", "k1", "yo", "k1", "k1", "p1", "k1", "p1", "k1", "p1"]))
-    }
-
-    func testNestedArrayBuilderWithTimesOneRepeat() throws {
-        let result = try NestedArrayBuilder().arrayMaker(row: "k1 p1 (1x) k4")
-        expect(result).to(equal(["k1", "p1", "k4"]))
-    }
-
-    func testNestedArrayBuilderWithK1TimesFourRepeat() throws {
-        let result = try NestedArrayBuilder().arrayMaker(row: "k1 (4x)")
-        expect(result).to(equal(["k1", "k1", "k1", "k1"]))
-    }
-
-    func testNestedArrayBuilderWithTimesZeroThrowsError() throws {
-        expect{try NestedArrayBuilder().arrayMaker(row: "k1 (0x)")}.to(throwError(InputError.invalidRepeatCount))
-    }
 }
 
 class MultipleStitchExpanderTest: XCTestCase {
 
     func testExpandValidMultipleStitch() throws {
-        let result = try NestedArrayBuilder().expandRow(row: ["k4", "p1"])
+        let result = NestedArrayBuilder().expandRow(row: ["k4", "p1"])
         expect(result).to(equal(["k1", "k1", "k1", "k1", "p1"]))
     }
 
 
     func testValidNonExpandingStitchesDontExpand() throws {
-        let result = try NestedArrayBuilder().expandRow(row: ["k1", "p1"])
+        let result = NestedArrayBuilder().expandRow(row: ["k1", "p1"])
         expect(result).to(equal(["k1", "p1"]))
+    }
 
-        func testInvalidZeroCountStitch() throws {
-            expect {
-                try NestedArrayBuilder().expandRow(row: ["k0", "p1"])
-            }
-            .to(throwError(
-                InputError.invalidStitchNumber(
-                    rowNumber: nil,
-                    invalidStitch: "k0",
-                    validStitchType: "k",
-                    invalidStitchNumber: "0")
-            ))
-        }
-
-        func testInvalidWordCountStitch() throws {
-            expect {
-                try NestedArrayBuilder().expandRow(row: ["kx", "py"])
-            }
-            .to(throwError(
-                InputError.invalidStitchNumber(
-                    rowNumber: nil,
-                    invalidStitch: "kx",
-                    validStitchType: "k",
-                    invalidStitchNumber: "x")
-            ))
-
-        }
+    func testExpandValidRepeatStitch() throws {
+        let result = NestedArrayBuilder().expandRow(row: ["k1", "p1", "(2x)"])
+        expect(result).to(equal(["k1", "p1", "k1", "p1"]))
     }
 
 
-
 }
+


### PR DESCRIPTION
Major redesign that touched a lot of different things. We now collect all errors in the form of `Result<Success, InputError>` types (`Success` being a new custom enum) and look for errors in `Chartify`.
- Modify `Chartify` to look through `Results`.
- Add row counts to all errors in `Errors`
- In `InputValidator`: Add new type `PatternDataAndPossibleErrors` and new enum `Success`. 
- `PatternDataAndPossibleErrors` is now returned by `inputValidator.validateinput`
- modify tests accordingly